### PR TITLE
PARQUET-16: Avoid calling getFileStatus() on all part-files

### DIFF
--- a/parquet-hadoop/src/test/java/parquet/hadoop/TestInputFormat.java
+++ b/parquet-hadoop/src/test/java/parquet/hadoop/TestInputFormat.java
@@ -340,7 +340,7 @@ public class TestInputFormat {
   public void testFooterCacheValueIsCurrent() throws IOException, InterruptedException {
     File tempFile = getTempFile();
     FileSystem fs = FileSystem.getLocal(new Configuration());
-    ParquetInputFormat.CachedFooter cacheValue = getDummyCacheValue(tempFile, fs);
+    ParquetInputFormat.FootersCacheValue cacheValue = getDummyCacheValue(tempFile, fs);
 
     assertTrue(tempFile.setLastModified(tempFile.lastModified() + 5000));
     assertFalse(cacheValue.isCurrent(new ParquetInputFormat.FileStatusWrapper(fs.getFileStatus(new Path(tempFile.getAbsolutePath())))));
@@ -350,13 +350,13 @@ public class TestInputFormat {
   public void testFooterCacheValueIsNewer() throws IOException {
     File tempFile = getTempFile();
     FileSystem fs = FileSystem.getLocal(new Configuration());
-    ParquetInputFormat.CachedFooter cacheValue = getDummyCacheValue(tempFile, fs);
+    ParquetInputFormat.FootersCacheValue cacheValue = getDummyCacheValue(tempFile, fs);
 
     assertTrue(cacheValue.isNewerThan(null));
     assertFalse(cacheValue.isNewerThan(cacheValue));
 
     assertTrue(tempFile.setLastModified(tempFile.lastModified() + 5000));
-    ParquetInputFormat.CachedFooter newerCacheValue = getDummyCacheValue(tempFile, fs);
+    ParquetInputFormat.FootersCacheValue newerCacheValue = getDummyCacheValue(tempFile, fs);
 
     assertTrue(newerCacheValue.isNewerThan(cacheValue));
     assertFalse(cacheValue.isNewerThan(newerCacheValue));
@@ -368,13 +368,13 @@ public class TestInputFormat {
     return tempFile;
   }
 
-  private ParquetInputFormat.CachedFooter getDummyCacheValue(File file, FileSystem fs) throws IOException {
+  private ParquetInputFormat.FootersCacheValue getDummyCacheValue(File file, FileSystem fs) throws IOException {
     Path path = new Path(file.getPath());
     FileStatus status = fs.getFileStatus(path);
     ParquetInputFormat.FileStatusWrapper statusWrapper = new ParquetInputFormat.FileStatusWrapper(status);
     ParquetMetadata mockMetadata = mock(ParquetMetadata.class);
-    ParquetInputFormat.CachedFooter cacheValue =
-            new ParquetInputFormat.CachedFooter(statusWrapper, new Footer(path, mockMetadata));
+    ParquetInputFormat.FootersCacheValue cacheValue =
+            new ParquetInputFormat.FootersCacheValue(statusWrapper, new Footer(path, mockMetadata));
     assertTrue(cacheValue.isCurrent(statusWrapper));
     return cacheValue;
   }

--- a/parquet-hadoop/src/test/java/parquet/hadoop/TestInputFormat.java
+++ b/parquet-hadoop/src/test/java/parquet/hadoop/TestInputFormat.java
@@ -340,7 +340,7 @@ public class TestInputFormat {
   public void testFooterCacheValueIsCurrent() throws IOException, InterruptedException {
     File tempFile = getTempFile();
     FileSystem fs = FileSystem.getLocal(new Configuration());
-    ParquetInputFormat.FootersCacheValue cacheValue = getDummyCacheValue(tempFile, fs);
+    ParquetInputFormat.CachedFooter cacheValue = getDummyCacheValue(tempFile, fs);
 
     assertTrue(tempFile.setLastModified(tempFile.lastModified() + 5000));
     assertFalse(cacheValue.isCurrent(new ParquetInputFormat.FileStatusWrapper(fs.getFileStatus(new Path(tempFile.getAbsolutePath())))));
@@ -350,13 +350,13 @@ public class TestInputFormat {
   public void testFooterCacheValueIsNewer() throws IOException {
     File tempFile = getTempFile();
     FileSystem fs = FileSystem.getLocal(new Configuration());
-    ParquetInputFormat.FootersCacheValue cacheValue = getDummyCacheValue(tempFile, fs);
+    ParquetInputFormat.CachedFooter cacheValue = getDummyCacheValue(tempFile, fs);
 
     assertTrue(cacheValue.isNewerThan(null));
     assertFalse(cacheValue.isNewerThan(cacheValue));
 
     assertTrue(tempFile.setLastModified(tempFile.lastModified() + 5000));
-    ParquetInputFormat.FootersCacheValue newerCacheValue = getDummyCacheValue(tempFile, fs);
+    ParquetInputFormat.CachedFooter newerCacheValue = getDummyCacheValue(tempFile, fs);
 
     assertTrue(newerCacheValue.isNewerThan(cacheValue));
     assertFalse(cacheValue.isNewerThan(newerCacheValue));
@@ -368,13 +368,13 @@ public class TestInputFormat {
     return tempFile;
   }
 
-  private ParquetInputFormat.FootersCacheValue getDummyCacheValue(File file, FileSystem fs) throws IOException {
+  private ParquetInputFormat.CachedFooter getDummyCacheValue(File file, FileSystem fs) throws IOException {
     Path path = new Path(file.getPath());
     FileStatus status = fs.getFileStatus(path);
     ParquetInputFormat.FileStatusWrapper statusWrapper = new ParquetInputFormat.FileStatusWrapper(status);
     ParquetMetadata mockMetadata = mock(ParquetMetadata.class);
-    ParquetInputFormat.FootersCacheValue cacheValue =
-            new ParquetInputFormat.FootersCacheValue(statusWrapper, new Footer(path, mockMetadata));
+    ParquetInputFormat.CachedFooter cacheValue =
+            new ParquetInputFormat.CachedFooter(statusWrapper, new Footer(path, mockMetadata));
     assertTrue(cacheValue.isCurrent(statusWrapper));
     return cacheValue;
   }


### PR DESCRIPTION
JIRA issue: [PARQUET-16](https://issues.apache.org/jira/browse/PARQUET-16)

This PR improves performance of `ParquetInputFormat.getSplit(JobContext)`, especially when reading large files from S3.

When calling `getSplits(JobContext)`, all the `FileStatus` objects are already fetched via `listStatus`, but abandoned immediately. PR #2 added an LRU cache for `Footer` objects, and fortunately corresponding `FileStatus` objects are cached together. In this PR, two private methods are added to leverage the LRU cache and prevent retrieving `FileStatus` objects sequentially when calling `getSplits(JobContext)`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/incubator-parquet-mr/17)
<!-- Reviewable:end -->
