### PR TITLE
PARQUET-181: Scrooge Write Support (take two)

### DIFF
--- a/parquet-cascading/src/main/java/parquet/cascading/ParquetTBaseScheme.java
+++ b/parquet-cascading/src/main/java/parquet/cascading/ParquetTBaseScheme.java
@@ -27,7 +27,7 @@ import parquet.hadoop.ParquetInputFormat;
 import parquet.hadoop.mapred.DeprecatedParquetInputFormat;
 import parquet.hadoop.mapred.DeprecatedParquetOutputFormat;
 import parquet.hadoop.thrift.ThriftReadSupport;
-import parquet.hadoop.thrift.ThriftWriteSupport;
+import parquet.hadoop.thrift.TBaseWriteSupport;
 import parquet.thrift.TBaseRecordConverter;
 
 public class ParquetTBaseScheme<T extends TBase<?,?>> extends ParquetValueScheme<T> {
@@ -71,7 +71,7 @@ public class ParquetTBaseScheme<T extends TBase<?,?>> extends ParquetValueScheme
     }
 
     jobConf.setOutputFormat(DeprecatedParquetOutputFormat.class);
-    DeprecatedParquetOutputFormat.setWriteSupportClass(jobConf, ThriftWriteSupport.class);
-    ThriftWriteSupport.<T>setThriftClass(jobConf, this.config.getKlass());
+    DeprecatedParquetOutputFormat.setWriteSupportClass(jobConf, TBaseWriteSupport.class);
+    TBaseWriteSupport.<T>setThriftClass(jobConf, this.config.getKlass());
   }
 }

--- a/parquet-scrooge/src/main/java/parquet/scrooge/ParquetScroogeOutputFormat.java
+++ b/parquet-scrooge/src/main/java/parquet/scrooge/ParquetScroogeOutputFormat.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.scrooge;
+
+import com.twitter.scrooge.ThriftStruct;
+import org.apache.hadoop.conf.Configuration;
+import parquet.hadoop.ParquetOutputFormat;
+
+/**
+ * Use this class to write Scrooge records to parquet
+ * @param <T>  Type of Scrooge records to write
+ */
+public class ParquetScroogeOutputFormat<T extends ThriftStruct> extends ParquetOutputFormat<T> {
+
+  public static void setScroogeClass(Configuration configuration, Class<? extends ThriftStruct> thriftClass) {
+    ScroogeWriteSupport.setScroogeClass(configuration, thriftClass);
+  }
+
+  public static Class<? extends ThriftStruct> getScroogeClass(Configuration configuration) {
+    return ScroogeWriteSupport.getScroogeClass(configuration);
+  }
+
+  public ParquetScroogeOutputFormat() {
+    super(new ScroogeWriteSupport<T>());
+  }
+}

--- a/parquet-scrooge/src/main/java/parquet/scrooge/ParquetScroogeScheme.java
+++ b/parquet-scrooge/src/main/java/parquet/scrooge/ParquetScroogeScheme.java
@@ -30,7 +30,9 @@ import cascading.tap.Tap;
 import parquet.cascading.ParquetValueScheme;
 import parquet.filter2.predicate.FilterPredicate;
 import parquet.hadoop.ParquetInputFormat;
+import parquet.hadoop.ParquetOutputFormat;
 import parquet.hadoop.mapred.DeprecatedParquetInputFormat;
+import parquet.hadoop.mapred.DeprecatedParquetOutputFormat;
 import parquet.hadoop.thrift.ThriftReadSupport;
 
 public class ParquetScroogeScheme<T extends ThriftStruct> extends ParquetValueScheme<T> {
@@ -50,16 +52,12 @@ public class ParquetScroogeScheme<T extends ThriftStruct> extends ParquetValueSc
   }
 
   @Override
-  public void sinkConfInit(FlowProcess<JobConf> arg0,
-      Tap<JobConf, RecordReader, OutputCollector> arg1, JobConf arg2) {
-    throw new UnsupportedOperationException("ParquetScroogeScheme does not support Sinks");
+  public void sinkConfInit(FlowProcess<JobConf> fp,
+      Tap<JobConf, RecordReader, OutputCollector> tap, JobConf jobConf) {
+    jobConf.setOutputFormat(DeprecatedParquetOutputFormat.class);
+    ParquetOutputFormat.setWriteSupportClass(jobConf, ScroogeWriteSupport.class);
+    ScroogeWriteSupport.setScroogeClass(jobConf, this.config.getKlass());
   }
-
-  /**
-   * TODO: currently we cannot write Parquet files from Scrooge objects.
-   */
-  @Override
-  public boolean isSink() { return false; }
 
   @Override
   public void sourceConfInit(FlowProcess<JobConf> fp,
@@ -68,11 +66,5 @@ public class ParquetScroogeScheme<T extends ThriftStruct> extends ParquetValueSc
     jobConf.setInputFormat(DeprecatedParquetInputFormat.class);
     ParquetInputFormat.setReadSupportClass(jobConf, ScroogeReadSupport.class);
     ThriftReadSupport.setRecordConverterClass(jobConf, ScroogeRecordConverter.class);
-  }
-
-  @Override
-  public void sink(FlowProcess<JobConf> arg0, SinkCall<Object[], OutputCollector> arg1)
-      throws IOException {
-    throw new UnsupportedOperationException("ParquetScroogeScheme does not support Sinks");
   }
 }

--- a/parquet-scrooge/src/main/java/parquet/scrooge/ScroogeWriteSupport.java
+++ b/parquet-scrooge/src/main/java/parquet/scrooge/ScroogeWriteSupport.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.scrooge;
+
+import com.twitter.scrooge.ThriftStruct;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.thrift.TException;
+
+import parquet.hadoop.thrift.AbstractThriftWriteSupport;
+import parquet.io.ParquetEncodingException;
+import parquet.thrift.struct.ThriftType.StructType;
+
+/**
+ * Write support for Scrooge
+ */
+public class ScroogeWriteSupport<T extends ThriftStruct> extends AbstractThriftWriteSupport<T> {
+  public static void setScroogeClass(Configuration configuration, Class<? extends ThriftStruct> thriftClass) {
+    AbstractThriftWriteSupport.setGenericThriftClass(configuration, thriftClass);
+  }
+
+  public static Class<? extends ThriftStruct> getScroogeClass(Configuration configuration) {
+    return (Class<? extends ThriftStruct>)AbstractThriftWriteSupport.getGenericThriftClass(configuration);
+  }
+
+  /**
+   * used from hadoop
+   * the configuration must contain a "parquet.thrift.write.class" setting
+   * (see ScroogeWriteSupport#setScroogeClass)
+   */
+  public ScroogeWriteSupport() {
+  }
+
+  public ScroogeWriteSupport(Class<T> thriftClass) {
+    super(thriftClass);
+  }
+
+  @Override
+  protected StructType getThriftStruct() {
+    ScroogeStructConverter schemaConverter = new ScroogeStructConverter();
+    return schemaConverter.convert(thriftClass);
+  }
+
+  @Override
+  public void write(T record) {
+    try {
+      record.write(parquetWriteProtocol);
+    } catch (TException e) {
+      throw new ParquetEncodingException(e);
+    }
+  }
+}

--- a/parquet-scrooge/src/test/resources/names.txt
+++ b/parquet-scrooge/src/test/resources/names.txt
@@ -1,0 +1,3 @@
+Alice	Practice
+Bob	Hope
+Charlie	Horse

--- a/parquet-thrift/src/main/java/parquet/hadoop/thrift/AbstractThriftWriteSupport.java
+++ b/parquet-thrift/src/main/java/parquet/hadoop/thrift/AbstractThriftWriteSupport.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.hadoop.thrift;
+
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.thrift.TBase;
+
+import com.twitter.elephantbird.pig.util.ThriftToPig;
+
+import parquet.Log;
+import parquet.hadoop.BadConfigurationException;
+import parquet.hadoop.api.WriteSupport;
+import parquet.io.ColumnIOFactory;
+import parquet.io.MessageColumnIO;
+import parquet.io.ParquetEncodingException;
+import parquet.io.api.RecordConsumer;
+import parquet.pig.PigMetaData;
+import parquet.schema.MessageType;
+import parquet.thrift.ParquetWriteProtocol;
+import parquet.thrift.ThriftMetaData;
+import parquet.thrift.ThriftSchemaConverter;
+import parquet.thrift.struct.ThriftType.StructType;
+
+
+public abstract class AbstractThriftWriteSupport<T> extends WriteSupport<T> {
+  public static final String PARQUET_THRIFT_CLASS = "parquet.thrift.class";
+  private static final Log LOG = Log.getLog(AbstractThriftWriteSupport.class);
+
+  public static void setGenericThriftClass(Configuration configuration, Class<?> thriftClass) {
+    configuration.set(PARQUET_THRIFT_CLASS, thriftClass.getName());
+  }
+
+  public static Class getGenericThriftClass(Configuration configuration) {
+    final String thriftClassName = configuration.get(PARQUET_THRIFT_CLASS);
+    if (thriftClassName == null) {
+      throw new BadConfigurationException("the thrift class conf is missing in job conf at " + PARQUET_THRIFT_CLASS);
+    }
+
+    try {
+      @SuppressWarnings("unchecked")
+      Class thriftClass = Class.forName(thriftClassName);
+      return thriftClass;
+    } catch (ClassNotFoundException e) {
+      throw new BadConfigurationException("the class "+thriftClassName+" in job conf at " + PARQUET_THRIFT_CLASS + " could not be found", e);
+    }
+  }
+
+  protected Class<T> thriftClass;
+  protected MessageType schema;
+  protected StructType thriftStruct;
+  protected ParquetWriteProtocol parquetWriteProtocol;
+  protected WriteContext writeContext;
+
+  /**
+   * used from hadoop
+   * the configuration must contain a thriftClass setting
+   * @see AbstractThriftWriteSupport#setThriftClass(Configuration, Class)
+   */
+  public AbstractThriftWriteSupport() {
+  }
+
+  /**
+   * @param thriftClass the thrift class used for writing values
+   */
+  public AbstractThriftWriteSupport(Class<T> thriftClass) {
+    init(thriftClass);
+  }
+
+  protected void init(Class<T> thriftClass) {
+    this.thriftClass = thriftClass;
+    this.thriftStruct = getThriftStruct();
+
+    ThriftSchemaConverter thriftSchemaConverter = new ThriftSchemaConverter();
+    this.schema = thriftSchemaConverter.convert(thriftStruct);
+
+    final Map<String, String> extraMetaData = new ThriftMetaData(thriftClass.getName(), thriftStruct).toExtraMetaData();
+    // adding the Pig schema as it would have been mapped from thrift
+    // TODO: make this work for non-tbase types
+    if (isPigLoaded() && TBase.class.isAssignableFrom(thriftClass)) {
+      new PigMetaData(new ThriftToPig((Class<? extends TBase<?,?>>)thriftClass).toSchema()).addToMetaData(extraMetaData);
+    }
+
+    this.writeContext = new WriteContext(schema, extraMetaData);
+  }
+
+  protected boolean isPigLoaded() {
+    try {
+      Class.forName("org.apache.pig.impl.logicalLayer.schema.Schema");
+      return true;
+    } catch (ClassNotFoundException e) {
+      LOG.info("Pig is not loaded, pig metadata will not be written");
+      return false;
+    }
+  }
+
+  @Override
+  public WriteContext init(Configuration configuration) {
+    if (writeContext == null) {
+      init(getGenericThriftClass(configuration));
+    }
+    return writeContext;
+  }
+
+  @Override
+  public void prepareForWrite(RecordConsumer recordConsumer) {
+    final MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(schema);
+    this.parquetWriteProtocol = new ParquetWriteProtocol(recordConsumer, columnIO, thriftStruct);
+  }
+
+  protected abstract StructType getThriftStruct();
+}

--- a/parquet-thrift/src/main/java/parquet/hadoop/thrift/ParquetThriftBytesOutputFormat.java
+++ b/parquet-thrift/src/main/java/parquet/hadoop/thrift/ParquetThriftBytesOutputFormat.java
@@ -35,11 +35,11 @@ import parquet.thrift.FieldIgnoredHandler;
 public class ParquetThriftBytesOutputFormat extends ParquetOutputFormat<BytesWritable> {
 
   public static void setThriftClass(Job job, Class<? extends TBase<?, ?>> thriftClass) {
-    ThriftWriteSupport.setThriftClass(ContextUtil.getConfiguration(job), thriftClass);
+    TBaseWriteSupport.setThriftClass(ContextUtil.getConfiguration(job), thriftClass);
   }
 
   public static Class<? extends TBase<?,?>> getThriftClass(Job job) {
-    return ThriftWriteSupport.getThriftClass(ContextUtil.getConfiguration(job));
+    return TBaseWriteSupport.getThriftClass(ContextUtil.getConfiguration(job));
   }
 
   public static <U extends TProtocol> void setTProtocolClass(Job job, Class<U> tProtocolClass) {

--- a/parquet-thrift/src/main/java/parquet/hadoop/thrift/TBaseWriteSupport.java
+++ b/parquet-thrift/src/main/java/parquet/hadoop/thrift/TBaseWriteSupport.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.hadoop.thrift;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+
+import parquet.hadoop.BadConfigurationException;
+import parquet.io.ParquetEncodingException;
+import parquet.thrift.ThriftSchemaConverter;
+import parquet.thrift.struct.ThriftType.StructType;
+
+public class TBaseWriteSupport<T extends TBase<?, ?>> extends AbstractThriftWriteSupport<T> {
+
+  public static <U extends TBase<?,?>> void setThriftClass(Configuration configuration, Class<U> thriftClass) {
+    AbstractThriftWriteSupport.setGenericThriftClass(configuration, thriftClass);
+  }
+
+  public static Class<? extends TBase<?,?>> getThriftClass(Configuration configuration) {
+    return (Class<? extends TBase<?,?>>)AbstractThriftWriteSupport.getGenericThriftClass(configuration);
+  }
+
+  /**
+   * used from hadoop
+   * the configuration must contain a thriftClass setting
+   * @see TBaseWriteSupport#setThriftClass(Configuration, Class)
+   */
+  public TBaseWriteSupport() {
+  }
+
+  public TBaseWriteSupport(Class<T> thriftClass) {
+    super(thriftClass);
+  }
+
+  @Override
+  protected StructType getThriftStruct() {
+    ThriftSchemaConverter thriftSchemaConverter = new ThriftSchemaConverter();
+    return thriftSchemaConverter.toStructType((Class<TBase<?, ?>>)thriftClass);
+  }
+
+  @Override
+  public void write(T record) {
+    try {
+      record.write(parquetWriteProtocol);
+    } catch (TException e) {
+      throw new ParquetEncodingException(e);
+    }
+  }
+}

--- a/parquet-thrift/src/main/java/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
+++ b/parquet-thrift/src/main/java/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
@@ -64,10 +64,10 @@ public class ThriftBytesWriteSupport extends WriteSupport<BytesWritable> {
 
   private final boolean buffered;
   @SuppressWarnings("rawtypes") // TODO: fix type
-  private final ThriftWriteSupport<?> thriftWriteSupport = new ThriftWriteSupport();
+  private final TBaseWriteSupport<?> thriftWriteSupport = new TBaseWriteSupport();
   private ProtocolPipe readToWrite;
   private TProtocolFactory protocolFactory;
-  private Class<? extends TBase<?, ?>> thriftClass;
+  private Class<? extends TBase<?,?>> thriftClass;
   private MessageType schema;
   private StructType thriftStruct;
   private ParquetWriteProtocol parquetWriteProtocol;
@@ -101,13 +101,13 @@ public class ThriftBytesWriteSupport extends WriteSupport<BytesWritable> {
       }
     }
     if (thriftClass != null) {
-      ThriftWriteSupport.setThriftClass(configuration, thriftClass);
+      TBaseWriteSupport.setThriftClass(configuration, thriftClass);
     } else {
-      thriftClass = ThriftWriteSupport.getThriftClass(configuration);
+      thriftClass = TBaseWriteSupport.getThriftClass(configuration);
     }
     ThriftSchemaConverter thriftSchemaConverter = new ThriftSchemaConverter();
     this.thriftStruct = thriftSchemaConverter.toStructType(thriftClass);
-    this.schema = thriftSchemaConverter.convert(thriftClass);
+    this.schema = thriftSchemaConverter.convert(thriftStruct);
     if (buffered) {
       readToWrite = new BufferedProtocolReadToWrite(thriftStruct, errorHandler);
     } else {

--- a/parquet-thrift/src/main/java/parquet/thrift/ThriftMetaData.java
+++ b/parquet-thrift/src/main/java/parquet/thrift/ThriftMetaData.java
@@ -68,9 +68,6 @@ public class ThriftMetaData {
   public static Class<?> getThriftClass(String thriftClassName) {
     try {
       Class<?> thriftClass = Class.forName(thriftClassName);
-      if (!TBase.class.isAssignableFrom(thriftClass)) {
-        throw new BadConfigurationException("Provided class " + thriftClassName + " does not extend TBase");
-      }
       return thriftClass;
     } catch (ClassNotFoundException e) {
       throw new BadConfigurationException("Could not instantiate thrift class " + thriftClassName, e);

--- a/parquet-thrift/src/main/java/parquet/thrift/ThriftParquetWriter.java
+++ b/parquet-thrift/src/main/java/parquet/thrift/ThriftParquetWriter.java
@@ -23,7 +23,7 @@ import org.apache.thrift.TBase;
 
 import parquet.hadoop.ParquetWriter;
 import parquet.hadoop.metadata.CompressionCodecName;
-import parquet.hadoop.thrift.ThriftWriteSupport;
+import parquet.hadoop.thrift.TBaseWriteSupport;
 
 /**
  * To generate Parquet files using thrift
@@ -35,15 +35,15 @@ import parquet.hadoop.thrift.ThriftWriteSupport;
 public class ThriftParquetWriter<T extends TBase<?,?>> extends ParquetWriter<T> {
 
   public ThriftParquetWriter(Path file, Class<T> thriftClass, CompressionCodecName compressionCodecName) throws IOException {
-    super(file, new ThriftWriteSupport<T>(thriftClass), compressionCodecName, ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.DEFAULT_PAGE_SIZE);
+    super(file, new TBaseWriteSupport<T>(thriftClass), compressionCodecName, ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.DEFAULT_PAGE_SIZE);
   }
 
   public ThriftParquetWriter(Path file, Class<T> thriftClass, CompressionCodecName compressionCodecName, int blockSize, int pageSize, boolean enableDictionary, boolean validating) throws IOException {
-    super(file, new ThriftWriteSupport<T>(thriftClass), compressionCodecName, blockSize, pageSize, enableDictionary, validating);
+    super(file, new TBaseWriteSupport<T>(thriftClass), compressionCodecName, blockSize, pageSize, enableDictionary, validating);
   }
 
   public ThriftParquetWriter(Path file, Class<T> thriftClass, CompressionCodecName compressionCodecName, int blockSize, int pageSize, boolean enableDictionary, boolean validating, Configuration conf) throws IOException {
-    super(file, new ThriftWriteSupport<T>(thriftClass), compressionCodecName,
+    super(file, new TBaseWriteSupport<T>(thriftClass), compressionCodecName,
         blockSize, pageSize, pageSize, enableDictionary, validating,
         DEFAULT_WRITER_VERSION, conf);
   }


### PR DESCRIPTION
This is similar to https://github.com/apache/incubator-parquet-mr/pull/43, but instead of making `ThriftWriteSupport` abstract, it keeps it around (but deprecated) and adds `AbstractThriftWriteSupport`. This is a little less elegant, but it seems to appease the semver overlords.