### PR TITLE
PARQUET-133: Upgrade snappy-java to 1.1.1.6

### DIFF
--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.0.5</version>
+      <version>1.1.1.6</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
Upgrade snappy-java to 1.1.1.6 (the latest vesrion), since 1.0.5 is no longer maintained in https://github.com/xerial/snappy-java, and 1.1.1.6 supports broader platforms including PowerPC, IBM-AIX 6.4, SunOS, etc. And also it has a better native coding loading mechanism (allowing to use snappy-java from multiple class loaders)