### PR TITLE
PARQUET-141: upgrade to scrooge 3.17.0, remove reflection based field info inspection...

### DIFF
--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>scrooge-core_${scala.binary.version}</artifactId>
-      <version>3.16.3</version>
+      <version>3.17.0</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
@@ -167,7 +167,7 @@
         <plugin>
             <groupId>com.twitter</groupId>
             <artifactId>scrooge-maven-plugin</artifactId>
-            <version>3.9.2</version>
+            <version>3.17.0</version>
             <configuration>
                 <outputDirectory>${project.build.directory}/generated-test-sources/scrooge</outputDirectory>
                 <thriftNamespaceMappings>

--- a/parquet-scrooge/src/main/java/parquet/scrooge/ScroogeSchemaConversionException.java
+++ b/parquet-scrooge/src/main/java/parquet/scrooge/ScroogeSchemaConversionException.java
@@ -1,0 +1,18 @@
+package parquet.scrooge;
+
+import parquet.ParquetRuntimeException;
+
+/**
+ * Throw this exception when there is an error converting a Scrooge class to
+ * thrift schema
+ */
+class ScroogeSchemaConversionException extends ParquetRuntimeException {
+  public ScroogeSchemaConversionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ScroogeSchemaConversionException(String message) {
+    super(message);
+  }
+}
+

--- a/parquet-scrooge/src/test/java/parquet/scrooge/ScroogeStructConverterTest.java
+++ b/parquet-scrooge/src/test/java/parquet/scrooge/ScroogeStructConverterTest.java
@@ -33,11 +33,12 @@ public class ScroogeStructConverterTest {
 
   }
 
-// Union support is broken due to scrooge not generating fieldInfos for union, need to be fixed
-//  @Test
-//  public void testUnion() throws Exception {
-//    new ScroogeStructConverter().convert(TestUnion.class);
-//  }
+  @Test
+  public void testUnion() throws Exception {
+    ThriftType.StructType expected = new ThriftSchemaConverter().toStructType(parquet.thrift.test.TestUnion.class);
+    ThriftType.StructType scroogeUnion = new ScroogeStructConverter().convert(TestUnion.class);
+    assertEquals(expected, scroogeUnion);
+  }
 
   @Test
   public void testConvertPrimitiveMapValue() throws Exception{

--- a/parquet-scrooge/src/test/java/parquet/scrooge/ScroogeStructConverterTest.java
+++ b/parquet-scrooge/src/test/java/parquet/scrooge/ScroogeStructConverterTest.java
@@ -16,7 +16,17 @@
 package parquet.scrooge;
 
 import org.junit.Test;
-import parquet.scrooge.test.*;
+
+import parquet.scrooge.test.AddressWithStreetWithDefaultRequirement;
+import parquet.scrooge.test.TestFieldOfEnum;
+import parquet.scrooge.test.TestListPrimitive;
+import parquet.scrooge.test.TestMapComplex;
+import parquet.scrooge.test.TestMapPrimitiveKey;
+import parquet.scrooge.test.TestMapPrimitiveValue;
+import parquet.scrooge.test.TestOptionalMap;
+import parquet.scrooge.test.TestPersonWithAllInformation;
+import parquet.scrooge.test.TestSetPrimitive;
+import parquet.scrooge.test.TestUnion;
 import parquet.thrift.ThriftSchemaConverter;
 import parquet.thrift.struct.ThriftType;
 import static org.junit.Assert.assertEquals;

--- a/parquet-scrooge/src/test/java/parquet/scrooge/ScroogeStructConverterTest.java
+++ b/parquet-scrooge/src/test/java/parquet/scrooge/ScroogeStructConverterTest.java
@@ -16,15 +16,7 @@
 package parquet.scrooge;
 
 import org.junit.Test;
-import parquet.scrooge.test.AddressWithStreetWithDefaultRequirement;
-import parquet.scrooge.test.TestFieldOfEnum;
-import parquet.scrooge.test.TestListPrimitive;
-import parquet.scrooge.test.TestMapComplex;
-import parquet.scrooge.test.TestMapPrimitiveKey;
-import parquet.scrooge.test.TestMapPrimitiveValue;
-import parquet.scrooge.test.TestOptionalMap;
-import parquet.scrooge.test.TestPersonWithAllInformation;
-import parquet.scrooge.test.TestSetPrimitive;
+import parquet.scrooge.test.*;
 import parquet.thrift.ThriftSchemaConverter;
 import parquet.thrift.struct.ThriftType;
 import static org.junit.Assert.assertEquals;
@@ -40,6 +32,12 @@ public class ScroogeStructConverterTest {
     assertEquals(expected,scroogeMap);
 
   }
+
+// Union support is broken due to scrooge not generating fieldInfos for union, need to be fixed
+//  @Test
+//  public void testUnion() throws Exception {
+//    new ScroogeStructConverter().convert(TestUnion.class);
+//  }
 
   @Test
   public void testConvertPrimitiveMapValue() throws Exception{
@@ -92,7 +90,7 @@ public class ScroogeStructConverterTest {
   public void testDefaultFields() throws Exception{
     ThriftType.StructType scroogePerson = new ScroogeStructConverter().convert(AddressWithStreetWithDefaultRequirement.class);
     ThriftType.StructType expected = new ThriftSchemaConverter().toStructType(parquet.thrift.test.AddressWithStreetWithDefaultRequirement.class);
-//    assertEquals(expected.toJSON(), scroogePerson.toJSON());
+    assertEquals(expected.toJSON(), scroogePerson.toJSON());
   }
 
   @Test

--- a/parquet-scrooge/src/test/thrift/test.thrift
+++ b/parquet-scrooge/src/test/thrift/test.thrift
@@ -133,6 +133,11 @@ struct TestMapPrimitiveValue {
   7: required map<string,string> string_map
 }
 
+//union TestUnion {
+//  1: TestPerson first_person
+//  2: TestMapComplex second_map
+//}
+
 enum Operation {
   ADD = 1,
   SUBTRACT = 2,

--- a/parquet-scrooge/src/test/thrift/test.thrift
+++ b/parquet-scrooge/src/test/thrift/test.thrift
@@ -133,10 +133,10 @@ struct TestMapPrimitiveValue {
   7: required map<string,string> string_map
 }
 
-//union TestUnion {
-//  1: TestPerson first_person
-//  2: TestMapComplex second_map
-//}
+union TestUnion {
+  1: TestPerson first_person
+  2: TestMapComplex second_map
+}
 
 enum Operation {
   ADD = 1,

--- a/pom.xml
+++ b/pom.xml
@@ -479,5 +479,4 @@
       </properties>
     </profile>
   </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
       <name>Nexus Release Repository</name>
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
-
   </distributionManagement>
 
   <repositories>


### PR DESCRIPTION
upgrade to scrooge 3.17.0, remove reflection based field info inspection, support enum and requirement type correctly

This PR is essential for scrooge write support https://github.com/apache/incubator-parquet-mr/pull/58