### PR TITLE
added ParquetProtoStorer support for pig.

### DIFF
--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -53,9 +53,26 @@
       <version>${elephant-bird.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.twitter.elephantbird</groupId>
+      <artifactId>elephant-bird-pig</artifactId>
+      <version>${elephant-bird.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>parquet-pig</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pig</groupId>
+      <artifactId>pig</artifactId>
+      <version>${pig.version}</version>
+      <classifier>${pig.classifier}</classifier>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/parquet-protobuf/src/main/java/parquet/proto/pig/ParquetProtoStorer.java
+++ b/parquet-protobuf/src/main/java/parquet/proto/pig/ParquetProtoStorer.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.proto.pig;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.pig.StoreFunc;
+import org.apache.pig.data.Tuple;
+
+import parquet.hadoop.ParquetOutputFormat;
+import parquet.io.ParquetEncodingException;
+
+/**
+ * To store in Pig using a proto class
+ * usage:
+ * STORE 'foo' USING parquet.proto.pig.ParquetProtoStorer('my.proto.Class');
+ *
+ * @author Peter Lin
+ *
+ */
+public class ParquetProtoStorer extends StoreFunc {
+
+  private RecordWriter<Void, Tuple> recordWriter;
+
+  private String className;
+
+  public ParquetProtoStorer(String[] params) {
+    if (params == null || params.length != 1) {
+      throw new IllegalArgumentException("required the proto class name in parameter. Got " + Arrays.toString(params) + " instead");
+    }
+    className = params[0];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public OutputFormat<Void, Tuple> getOutputFormat() throws IOException {
+    return new ParquetOutputFormat<Tuple>(new TupleToProtoWriteSupport(className));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @SuppressWarnings({ "rawtypes", "unchecked" }) // that's how the base class is defined
+  @Override
+  public void prepareToWrite(RecordWriter recordWriter) throws IOException {
+    this.recordWriter = recordWriter;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void putNext(Tuple tuple) throws IOException {
+    try {
+      this.recordWriter.write(null, tuple);
+    } catch (InterruptedException e) {
+      throw new ParquetEncodingException("Interrupted while writing", e);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setStoreLocation(String location, Job job) throws IOException {
+    FileOutputFormat.setOutputPath(job, new Path(location));
+  }
+
+}

--- a/parquet-protobuf/src/main/java/parquet/proto/pig/TupleToProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/parquet/proto/pig/TupleToProtoWriteSupport.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.proto.pig;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.pig.data.Tuple;
+import org.apache.thrift.TBase;
+
+import parquet.hadoop.BadConfigurationException;
+import parquet.hadoop.api.WriteSupport;
+import parquet.proto.ProtoWriteSupport;
+import parquet.io.api.RecordConsumer;
+
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
+import com.twitter.elephantbird.pig.util.PigToProtobuf;
+import com.twitter.elephantbird.util.Protobufs;
+
+/**
+ * Stores Pig tuples as Protobuf objects
+ *
+ * @author Peter Lin
+ *
+ */
+public class TupleToProtoWriteSupport extends WriteSupport<Tuple> {
+
+  private final String className;
+  private ProtoWriteSupport<MessageOrBuilder> protoWriteSupport;
+  private Class<? extends Message> protoClass;
+
+  /**
+   * @param className the thrift class name
+   */
+  public TupleToProtoWriteSupport(String className) {
+    super();
+    this.className = className;
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Override
+  public WriteContext init(Configuration configuration) {
+    try {
+      protoClass = Protobufs.getInnerProtobufClass(className);
+      protoWriteSupport = new ProtoWriteSupport(protoClass);
+      return protoWriteSupport.init(configuration);      
+    } catch (ClassCastException e) {
+      throw new BadConfigurationException("The protobuf class name should extend Message: " + className, e);
+    }
+  }
+
+  @Override
+  public void prepareForWrite(RecordConsumer recordConsumer) {
+    protoWriteSupport.prepareForWrite(recordConsumer);
+  }
+
+  @Override
+  public void write(Tuple t) {
+    protoWriteSupport.write(PigToProtobuf.tupleToMessage(protoClass, t));
+  }
+
+}


### PR DESCRIPTION
This is a simple implementation by following the thrift module to add the pig support for ParquetProtoStorer.