### PR TITLE
[PARQUET-133]: upgrade snappy-java to 1.1.1.6

### DIFF
--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.0.5</version>
+      <version>1.1.1.6</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/parquet-hadoop/src/test/java/parquet/format/converter/TestParquetMetadataConverter.java
+++ b/parquet-hadoop/src/test/java/parquet/format/converter/TestParquetMetadataConverter.java
@@ -244,7 +244,7 @@ public class TestParquetMetadataConverter {
       try {
         verifyAllFilters(metadata(rgs), splitSize);
       } catch (AssertionError e) {
-	  throw new AssertionError("fail verifyAllFilters(metadata(" + Arrays.toString(rgs) + "), " + splitSize + ")", e);
+	  throw new AssertionError("fail verifyAllFilters(metadata(" + Arrays.toString(rgs) + "), " + splitSize + ")");
       }
     }
   }


### PR DESCRIPTION
Upgraded snappy-java as requested by PARQUET-133.  Needed to do a global mvn clean before the tests passed cleanly though. Is there some cross contamination of test data?