### PR TITLE
PARQUET-136: NPE thrown in StatisticsFilter when all values in a string/binary column trunk are null

### DIFF
--- a/parquet-column/src/main/java/parquet/column/statistics/BinaryStatistics.java
+++ b/parquet-column/src/main/java/parquet/column/statistics/BinaryStatistics.java
@@ -24,7 +24,7 @@ public class BinaryStatistics extends Statistics<Binary> {
 
   @Override
   public void updateStats(Binary value) {
-    if (this.isEmpty()) {
+    if (!this.hasNonNullValue()) {
       initializeStats(value, value);
     } else {
       updateStats(value, value);
@@ -34,7 +34,7 @@ public class BinaryStatistics extends Statistics<Binary> {
   @Override
   public void mergeStatisticsMinMax(Statistics stats) {
     BinaryStatistics binaryStats = (BinaryStatistics)stats;
-    if (this.isEmpty()) {
+    if (!this.hasNonNullValue()) {
       initializeStats(binaryStats.getMin(), binaryStats.getMax());
     } else {
       updateStats(binaryStats.getMin(), binaryStats.getMax());
@@ -60,9 +60,11 @@ public class BinaryStatistics extends Statistics<Binary> {
 
   @Override
   public String toString() {
-    if(!this.isEmpty())
+    if (this.hasNonNullValue())
       return String.format("min: %s, max: %s, num_nulls: %d", min.toStringUsingUTF8(), max.toStringUsingUTF8(), this.getNumNulls());
-    else
+   else if (!this.isEmpty())
+      return String.format("num_nulls: %d, min/max not defined", this.getNumNulls());
+   else
       return "no stats for this column";
   }
 

--- a/parquet-column/src/main/java/parquet/column/statistics/BooleanStatistics.java
+++ b/parquet-column/src/main/java/parquet/column/statistics/BooleanStatistics.java
@@ -24,7 +24,7 @@ public class BooleanStatistics extends Statistics<Boolean> {
 
   @Override
   public void updateStats(boolean value) {
-    if (this.isEmpty()) {
+    if (!this.hasNonNullValue()) {
       initializeStats(value, value);
     } else {
       updateStats(value, value);
@@ -34,7 +34,7 @@ public class BooleanStatistics extends Statistics<Boolean> {
   @Override
   public void mergeStatisticsMinMax(Statistics stats) {
     BooleanStatistics boolStats = (BooleanStatistics)stats;
-    if (this.isEmpty()) {
+    if (!this.hasNonNullValue()) {
       initializeStats(boolStats.getMin(), boolStats.getMax());
     } else {
       updateStats(boolStats.getMin(), boolStats.getMax());
@@ -60,9 +60,11 @@ public class BooleanStatistics extends Statistics<Boolean> {
 
   @Override
   public String toString() {
-    if(!this.isEmpty())
+    if (this.hasNonNullValue())
       return String.format("min: %b, max: %b, num_nulls: %d", min, max, this.getNumNulls());
-    else
+    else if(!this.isEmpty())
+      return String.format("num_nulls: %d, min/max not defined", this.getNumNulls());
+    else  
       return "no stats for this column";
   }
 

--- a/parquet-column/src/main/java/parquet/column/statistics/DoubleStatistics.java
+++ b/parquet-column/src/main/java/parquet/column/statistics/DoubleStatistics.java
@@ -24,7 +24,7 @@ public class DoubleStatistics extends Statistics<Double> {
 
   @Override
   public void updateStats(double value) {
-    if (this.isEmpty()) {
+    if (!this.hasNonNullValue()) {
       initializeStats(value, value);
     } else {
       updateStats(value, value);
@@ -34,7 +34,7 @@ public class DoubleStatistics extends Statistics<Double> {
   @Override
   public void mergeStatisticsMinMax(Statistics stats) {
     DoubleStatistics doubleStats = (DoubleStatistics)stats;
-    if (this.isEmpty()) {
+    if (!this.hasNonNullValue()) {
       initializeStats(doubleStats.getMin(), doubleStats.getMax());
     } else {
       updateStats(doubleStats.getMin(), doubleStats.getMax());
@@ -60,8 +60,10 @@ public class DoubleStatistics extends Statistics<Double> {
 
   @Override
   public String toString() {
-    if(!this.isEmpty())
+    if(this.hasNonNullValue())
       return String.format("min: %.5f, max: %.5f, num_nulls: %d", min, max, this.getNumNulls());
+    else if (!this.isEmpty())
+      return String.format("num_nulls: %d, min/max not defined", this.getNumNulls());
     else
       return "no stats for this column";
   }

--- a/parquet-column/src/main/java/parquet/column/statistics/FloatStatistics.java
+++ b/parquet-column/src/main/java/parquet/column/statistics/FloatStatistics.java
@@ -24,7 +24,7 @@ public class FloatStatistics extends Statistics<Float> {
 
   @Override
   public void updateStats(float value) {
-    if (this.isEmpty()) {
+    if (!this.hasNonNullValue()) {
       initializeStats(value, value);
     } else {
       updateStats(value, value);
@@ -34,7 +34,7 @@ public class FloatStatistics extends Statistics<Float> {
   @Override
   public void mergeStatisticsMinMax(Statistics stats) {
     FloatStatistics floatStats = (FloatStatistics)stats;
-    if (this.isEmpty()) {
+    if (!this.hasNonNullValue()) {
       initializeStats(floatStats.getMin(), floatStats.getMax());
     } else {
       updateStats(floatStats.getMin(), floatStats.getMax());
@@ -60,8 +60,10 @@ public class FloatStatistics extends Statistics<Float> {
 
   @Override
   public String toString() {
-    if(!this.isEmpty())
+    if (this.hasNonNullValue())
       return String.format("min: %.5f, max: %.5f, num_nulls: %d", min, max, this.getNumNulls());
+    else if (!this.isEmpty())
+      return String.format("num_nulls: %d, min/max not defined", this.getNumNulls());
     else
       return "no stats for this column";
   }

--- a/parquet-column/src/main/java/parquet/column/statistics/IntStatistics.java
+++ b/parquet-column/src/main/java/parquet/column/statistics/IntStatistics.java
@@ -24,7 +24,7 @@ public class IntStatistics extends Statistics<Integer> {
 
   @Override
   public void updateStats(int value) {
-    if (this.isEmpty()) {
+    if (!this.hasNonNullValue()) {
       initializeStats(value, value);
     } else {
       updateStats(value, value);
@@ -34,7 +34,7 @@ public class IntStatistics extends Statistics<Integer> {
   @Override
   public void mergeStatisticsMinMax(Statistics stats) {
     IntStatistics intStats = (IntStatistics)stats;
-    if (this.isEmpty()) {
+    if (!this.hasNonNullValue()) {
       initializeStats(intStats.getMin(), intStats.getMax());
     } else {
       updateStats(intStats.getMin(), intStats.getMax());
@@ -60,8 +60,10 @@ public class IntStatistics extends Statistics<Integer> {
 
   @Override
   public String toString() {
-    if(!this.isEmpty())
+    if (this.hasNonNullValue())
       return String.format("min: %d, max: %d, num_nulls: %d", min, max, this.getNumNulls());
+    else if (!this.isEmpty())
+      return String.format("num_nulls: %d, min/max is not defined", this.getNumNulls());
     else
       return "no stats for this column";
   }

--- a/parquet-column/src/main/java/parquet/column/statistics/LongStatistics.java
+++ b/parquet-column/src/main/java/parquet/column/statistics/LongStatistics.java
@@ -24,7 +24,7 @@ public class LongStatistics extends Statistics<Long> {
 
   @Override
   public void updateStats(long value) {
-    if (this.isEmpty()) {
+    if (!this.hasNonNullValue()) {
       initializeStats(value, value);
     } else {
       updateStats(value, value);
@@ -34,7 +34,7 @@ public class LongStatistics extends Statistics<Long> {
   @Override
   public void mergeStatisticsMinMax(Statistics stats) {
     LongStatistics longStats = (LongStatistics)stats;
-    if (this.isEmpty()) {
+    if (!this.hasNonNullValue()) {
       initializeStats(longStats.getMin(), longStats.getMax());
     } else {
       updateStats(longStats.getMin(), longStats.getMax());
@@ -60,8 +60,10 @@ public class LongStatistics extends Statistics<Long> {
 
   @Override
   public String toString() {
-    if(!this.isEmpty())
+    if (this.hasNonNullValue())
       return String.format("min: %d, max: %d, num_nulls: %d", min, max, this.getNumNulls());
+    else if (!this.isEmpty())
+      return String.format("num_nulls: %d, min/max not defined", this.getNumNulls());
     else
       return "no stats for this column";
   }

--- a/parquet-column/src/main/java/parquet/column/statistics/Statistics.java
+++ b/parquet-column/src/main/java/parquet/column/statistics/Statistics.java
@@ -232,7 +232,11 @@ public abstract class Statistics<T extends Comparable<T>> {
   public boolean hasNonNullValue() {
     return hasNonNullValue;
   }
-  
+ 
+  /**
+   * Sets the page/column as having a valid non-null value
+   * kind of misnomer here
+   */ 
   protected void markAsNotEmpty() {
     hasNonNullValue = true;
   }

--- a/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
+++ b/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
@@ -72,9 +72,9 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
     return (column.getStatistics().isEmpty()) || (column.getStatistics().getNumNulls() == column.getValueCount());
   }
 
-  // are there any nulls in this column chunk?
+  // are there any nulls in this column chunk? 
   private boolean hasNulls(ColumnChunkMetaData column) {
-    return column.getStatistics().getNumNulls() > 0;
+    return (column.getStatistics().getNumNulls() > 0) || (isAllNulls(column));
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
+++ b/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
@@ -67,8 +67,9 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
   }
 
   // is this column chunk composed entirely of nulls?
+  // in case of all nulls, the stats object read from file metadata is empty
   private boolean isAllNulls(ColumnChunkMetaData column) {
-    return column.getStatistics().getNumNulls() == column.getValueCount();
+    return (column.getStatistics().isEmpty()) || (column.getStatistics().getNumNulls() == column.getValueCount());
   }
 
   // are there any nulls in this column chunk?

--- a/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
+++ b/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
@@ -81,6 +81,16 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
     Column<T> filterColumn = eq.getColumn();
     T value = eq.getValue();
     ColumnChunkMetaData columnChunk = getColumnChunk(filterColumn.getColumnPath());
+    Statistics<T> stats = columnChunk.getStatistics();
+
+    if (stats.isEmpty()) {
+     // Do not filter in case of empty statistics
+     // pre-statistics files will have no such info
+     // best not to filter these.
+     // Also, in case of all nulls in a column, empty statistics object 
+     // is returned. This fixes the read path because of that bug
+      return false;
+    }
 
     if (value == null) {
       // we are looking for records where v eq(null)
@@ -94,8 +104,6 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
       return true;
     }
 
-    Statistics<T> stats = columnChunk.getStatistics();
-
     // drop if value < min || value > max
     return value.compareTo(stats.genericGetMin()) < 0 || value.compareTo(stats.genericGetMax()) > 0;
   }
@@ -105,6 +113,16 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
     Column<T> filterColumn = notEq.getColumn();
     T value = notEq.getValue();
     ColumnChunkMetaData columnChunk = getColumnChunk(filterColumn.getColumnPath());
+    Statistics<T> stats = columnChunk.getStatistics();
+
+    if (stats.isEmpty()) {
+     // Do not filter in case of empty statistics
+     // pre-statistics files will have no such info
+     // best not to filter these.
+     // Also, in case of all nulls in a column, empty statistics object 
+     // is returned. This fixes the read path because of that bug
+      return false;
+    }
 
     if (value == null) {
       // we are looking for records where v notEq(null)
@@ -118,8 +136,6 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
       return false;
     }
 
-    Statistics<T> stats = columnChunk.getStatistics();
-
     // drop if this is a column where min = max = value
     return value.compareTo(stats.genericGetMin()) == 0 && value.compareTo(stats.genericGetMax()) == 0;
   }
@@ -129,14 +145,22 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
     Column<T> filterColumn = lt.getColumn();
     T value = lt.getValue();
     ColumnChunkMetaData columnChunk = getColumnChunk(filterColumn.getColumnPath());
+    Statistics<T> stats = columnChunk.getStatistics();
+
+    if (stats.isEmpty()) {
+     // Do not filter in case of empty statistics
+     // pre-statistics files will have no such info
+     // best not to filter these.
+     // Also, in case of all nulls in a column, empty statistics object 
+     // is returned. This fixes the read path because of that bug
+      return false;
+    }
 
     if (isAllNulls(columnChunk)) {
       // we are looking for records where v < someValue
       // this chunk is all nulls, so we can drop it
       return true;
     }
-
-    Statistics<T> stats = columnChunk.getStatistics();
 
     // drop if value <= min
     return  value.compareTo(stats.genericGetMin()) <= 0;
@@ -147,14 +171,22 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
     Column<T> filterColumn = ltEq.getColumn();
     T value = ltEq.getValue();
     ColumnChunkMetaData columnChunk = getColumnChunk(filterColumn.getColumnPath());
+    Statistics<T> stats = columnChunk.getStatistics();
+
+    if (stats.isEmpty()) {
+     // Do not filter in case of empty statistics
+     // pre-statistics files will have no such info
+     // best not to filter these.
+     // Also, in case of all nulls in a column, empty statistics object 
+     // is returned. This fixes the read path because of that bug
+      return false;
+    }
 
     if (isAllNulls(columnChunk)) {
       // we are looking for records where v <= someValue
       // this chunk is all nulls, so we can drop it
       return true;
     }
-
-    Statistics<T> stats = columnChunk.getStatistics();
 
     // drop if value < min
     return value.compareTo(stats.genericGetMin()) < 0;
@@ -165,14 +197,22 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
     Column<T> filterColumn = gt.getColumn();
     T value = gt.getValue();
     ColumnChunkMetaData columnChunk = getColumnChunk(filterColumn.getColumnPath());
+    Statistics<T> stats = columnChunk.getStatistics();
+
+    if (stats.isEmpty()) {
+     // Do not filter in case of empty statistics
+     // pre-statistics files will have no such info
+     // best not to filter these.
+     // Also, in case of all nulls in a column, empty statistics object 
+     // is returned. This fixes the read path because of that bug
+      return false;
+    }
 
     if (isAllNulls(columnChunk)) {
       // we are looking for records where v > someValue
       // this chunk is all nulls, so we can drop it
       return true;
     }
-
-    Statistics<T> stats = columnChunk.getStatistics();
 
     // drop if value >= max
     return value.compareTo(stats.genericGetMax()) >= 0;
@@ -183,14 +223,22 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
     Column<T> filterColumn = gtEq.getColumn();
     T value = gtEq.getValue();
     ColumnChunkMetaData columnChunk = getColumnChunk(filterColumn.getColumnPath());
+    Statistics<T> stats = columnChunk.getStatistics();
+
+    if (stats.isEmpty()) {
+     // Do not filter in case of empty statistics
+     // pre-statistics files will have no such info
+     // best not to filter these.
+     // Also, in case of all nulls in a column, empty statistics object 
+     // is returned. This fixes the read path because of that bug
+      return false;
+    }
 
     if (isAllNulls(columnChunk)) {
       // we are looking for records where v >= someValue
       // this chunk is all nulls, so we can drop it
       return true;
     }
-
-    Statistics<T> stats = columnChunk.getStatistics();
 
     // drop if value >= max
     return value.compareTo(stats.genericGetMax()) > 0;
@@ -221,6 +269,15 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
     ColumnChunkMetaData columnChunk = getColumnChunk(filterColumn.getColumnPath());
     U udp = ud.getUserDefinedPredicate();
     Statistics<T> stats = columnChunk.getStatistics();
+    if (stats.isEmpty()) {
+     // Do not filter in case of empty statistics
+     // pre-statistics files will have no such info
+     // best not to filter these.
+     // Also, in case of all nulls in a column, empty statistics object 
+     // is returned. This fixes the read path because of that bug
+      return false;
+    }
+
     parquet.filter2.predicate.Statistics<T> udpStats =
         new parquet.filter2.predicate.Statistics<T>(stats.genericGetMin(), stats.genericGetMax());
 

--- a/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
+++ b/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
@@ -72,9 +72,9 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
     return (column.getStatistics().isEmpty()) || (column.getStatistics().getNumNulls() == column.getValueCount());
   }
 
-  // are there any nulls in this column chunk? 
+  // are there any nulls in this column chunk?
   private boolean hasNulls(ColumnChunkMetaData column) {
-    return (column.getStatistics().getNumNulls() > 0) || (isAllNulls(column));
+    return column.getStatistics().getNumNulls() > 0;
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
+++ b/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
@@ -67,9 +67,8 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
   }
 
   // is this column chunk composed entirely of nulls?
-  // in case of all nulls, the stats object read from file metadata is empty
   private boolean isAllNulls(ColumnChunkMetaData column) {
-    return (column.getStatistics().isEmpty()) || (column.getStatistics().getNumNulls() == column.getValueCount());
+    return column.getStatistics().getNumNulls() == column.getValueCount();
   }
 
   // are there any nulls in this column chunk?

--- a/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
+++ b/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
@@ -130,13 +130,6 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
       return false;
     }
 
-    if (isAllNulls(columnChunk)) {
-      // there is no min max, there is nothing
-      // else we can say about this chunk, we
-      // cannot drop it.
-      return false;
-    }
-
     // drop if this is a column where min = max = value
     return value.compareTo(stats.genericGetMin()) == 0 && value.compareTo(stats.genericGetMax()) == 0;
   }

--- a/parquet-hadoop/src/main/java/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/parquet/format/converter/ParquetMetadataConverter.java
@@ -234,9 +234,11 @@ public class ParquetMetadataConverter {
   public static Statistics toParquetStatistics(parquet.column.statistics.Statistics statistics) {
     Statistics stats = new Statistics();
     if (!statistics.isEmpty()) {
-      stats.setMax(statistics.getMaxBytes());
-      stats.setMin(statistics.getMinBytes());
       stats.setNull_count(statistics.getNumNulls());
+      if(statistics.hasNonNullValue()) {
+        stats.setMax(statistics.getMaxBytes());
+        stats.setMin(statistics.getMinBytes());
+     }
     }
     return stats;
   }
@@ -246,7 +248,9 @@ public class ParquetMetadataConverter {
     parquet.column.statistics.Statistics stats = parquet.column.statistics.Statistics.getStatsBasedOnType(type);
     // If there was no statistics written to the footer, create an empty Statistics object and return
     if (statistics != null) {
-      stats.setMinMaxFromBytes(statistics.min.array(), statistics.max.array());
+      if (statistics.isSetMax() && statistics.isSetMin()) {
+        stats.setMinMaxFromBytes(statistics.min.array(), statistics.max.array());
+      }
       stats.setNumNulls(statistics.null_count);
     }
     return stats;

--- a/parquet-hadoop/src/test/java/parquet/filter2/statisticslevel/TestStatisticsFilter.java
+++ b/parquet-hadoop/src/test/java/parquet/filter2/statisticslevel/TestStatisticsFilter.java
@@ -279,10 +279,10 @@ public class TestStatisticsFilter {
   @Test
   public void testClearExceptionForNots() {
     List<ColumnChunkMetaData> columnMetas = Arrays.asList(
-        getIntColumnMeta(new IntStatistics(), 0L),
-        getDoubleColumnMeta(new DoubleStatistics(), 0L));
+        getDoubleColumnMeta(new DoubleStatistics(), 0L),
+        getIntColumnMeta(new IntStatistics(), 0L));
 
-    FilterPredicate pred = and(eq(intColumn, 17), not(eq(doubleColumn, 12.0)));
+    FilterPredicate pred = and(not(eq(doubleColumn, 12.0)), eq(intColumn, 17));
 
     try {
       canDrop(pred, columnMetas);
@@ -297,7 +297,7 @@ public class TestStatisticsFilter {
   public void testMissingColumn() {
     List<ColumnChunkMetaData> columnMetas = Arrays.asList(getIntColumnMeta(new IntStatistics(), 0L));
     try {
-      canDrop(and(eq(intColumn, 17), eq(doubleColumn, 12.0)), columnMetas);
+      canDrop(and(eq(doubleColumn, 12.0), eq(intColumn, 17)), columnMetas);
       fail("This should throw");
     } catch (IllegalArgumentException e) {
       assertEquals("Column double.column not found in schema!", e.getMessage());

--- a/parquet-hadoop/src/test/java/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/parquet/hadoop/TestParquetFileWriter.java
@@ -339,14 +339,11 @@ public class TestParquetFileWriter {
     writer.close();
     
     ParquetMetadata readFooter = ParquetFileReader.readFooter(configuration, path);
-    for (BlockMetaData block : readFooter.getBlocks()) {
-      for (ColumnChunkMetaData col : block.getColumns()) {
-        col.getPath();
-      }
-    }
-    { // assert the number of nulls are correct for the first block
-      assertEquals(1, (readFooter.getBlocks().get(0).getColumns().get(0).getStatistics().getNumNulls()));
-    }
+    
+    // assert the statistics object is not empty
+    assertTrue((readFooter.getBlocks().get(0).getColumns().get(0).getStatistics().isEmpty()) == false);
+    // assert the number of nulls are correct for the first block
+    assertEquals(1, (readFooter.getBlocks().get(0).getColumns().get(0).getStatistics().getNumNulls()));
   }
 
   private void validateFooters(final List<Footer> metadata) {

--- a/parquet-hadoop/src/test/java/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/parquet/hadoop/TestParquetFileWriter.java
@@ -340,7 +340,7 @@ public class TestParquetFileWriter {
     
     ParquetMetadata readFooter = ParquetFileReader.readFooter(configuration, path);
     
-    //  assert the statistics object is not empty
+    // assert the statistics object is not empty
     assertTrue((readFooter.getBlocks().get(0).getColumns().get(0).getStatistics().isEmpty()) == false);
     // assert the number of nulls are correct for the first block
     assertEquals(1, (readFooter.getBlocks().get(0).getColumns().get(0).getStatistics().getNumNulls()));

--- a/parquet-hadoop/src/test/java/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/parquet/hadoop/TestParquetFileWriter.java
@@ -340,7 +340,7 @@ public class TestParquetFileWriter {
     
     ParquetMetadata readFooter = ParquetFileReader.readFooter(configuration, path);
     
-    // assert the statistics object is not empty
+    //  assert the statistics object is not empty
     assertTrue((readFooter.getBlocks().get(0).getColumns().get(0).getStatistics().isEmpty()) == false);
     // assert the number of nulls are correct for the first block
     assertEquals(1, (readFooter.getBlocks().get(0).getColumns().get(0).getStatistics().getNumNulls()));


### PR DESCRIPTION
In case of all nulls in a binary column, statistics object read from file metadata is empty, and should return true for all nulls check for the column. Even if column has no values, it can be ignored.

The other way is to fix this behaviour in the writer, but is that what we want ?