### PR TITLE
PARQUET-174: Replaces AssertionError constructor introduced in Java7

### DIFF
--- a/parquet-hadoop/src/test/java/parquet/format/converter/TestParquetMetadataConverter.java
+++ b/parquet-hadoop/src/test/java/parquet/format/converter/TestParquetMetadataConverter.java
@@ -244,7 +244,7 @@ public class TestParquetMetadataConverter {
       try {
         verifyAllFilters(metadata(rgs), splitSize);
       } catch (AssertionError e) {
-	  throw new AssertionError("fail verifyAllFilters(metadata(" + Arrays.toString(rgs) + "), " + splitSize + ")", e);
+	  throw (AssertionError) new AssertionError("fail verifyAllFilters(metadata(" + Arrays.toString(rgs) + "), " + splitSize + ")").initCause(e);
       }
     }
   }


### PR DESCRIPTION
AssertionError(String, Throwable) was introduced in Java7. Replacing it with AssertionError(String) + initCause(Throwable)