### PR TITLE
PARQUET-157: Divide by zero fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ target
 *.orig
 *.rej
 dependency-reduced-pom.xml
+parquet-scrooge/.cache
 .idea/*
 target/


### PR DESCRIPTION
There is a divide by zero error in logging code inside the InternalParquetRecordReader. I've been running with this fixed for a while but everytime I revert I hit the problem again. I can't believe anyone else hasn't had this problem. I submitted a Jira ticket a few weeks ago but didn't hear anything on the list so here's the fix.

This also avoids compiling log statements in some cases where it's unnecessary inside the checkRead method of InternalParquetRecordReader.

Also added a .gitignore entry to clean up a build artifact.