### PR TITLE
PARQUET-161: Statistics should be written for column chunks that are all null

### DIFF
--- a/parquet-column/src/main/java/parquet/column/statistics/IntStatistics.java
+++ b/parquet-column/src/main/java/parquet/column/statistics/IntStatistics.java
@@ -24,7 +24,7 @@ public class IntStatistics extends Statistics<Integer> {
 
   @Override
   public void updateStats(int value) {
-    if (this.isEmpty()) {
+    if (this.isEmpty() || !this.hasValidValue()) {
       initializeStats(value, value);
     } else {
       updateStats(value, value);
@@ -34,7 +34,7 @@ public class IntStatistics extends Statistics<Integer> {
   @Override
   public void mergeStatisticsMinMax(Statistics stats) {
     IntStatistics intStats = (IntStatistics)stats;
-    if (this.isEmpty()) {
+    if (this.isEmpty() || !this.hasValidValue()) {
       initializeStats(intStats.getMin(), intStats.getMax());
     } else {
       updateStats(intStats.getMin(), intStats.getMax());
@@ -45,6 +45,7 @@ public class IntStatistics extends Statistics<Integer> {
   public void setMinMaxFromBytes(byte[] minBytes, byte[] maxBytes) {
     max = BytesUtils.bytesToInt(maxBytes);
     min = BytesUtils.bytesToInt(minBytes);
+    this.markHasValidValue();
     this.markAsNotEmpty();
   }
 
@@ -60,8 +61,10 @@ public class IntStatistics extends Statistics<Integer> {
 
   @Override
   public String toString() {
-    if(!this.isEmpty())
+    if(this.hasValidValue())
       return String.format("min: %d, max: %d, num_nulls: %d", min, max, this.getNumNulls());
+    else if(!this.isEmpty())
+      return String.format("num_nulls: %d, min/max not defined", this.getNumNulls());
     else
       return "no stats for this column";
   }
@@ -74,6 +77,7 @@ public class IntStatistics extends Statistics<Integer> {
   public void initializeStats(int min_value, int max_value) {
       min = min_value;
       max = max_value;
+      this.markHasValidValue();
       this.markAsNotEmpty();
   }
 
@@ -85,6 +89,24 @@ public class IntStatistics extends Statistics<Integer> {
   @Override
   public Integer genericGetMax() {
     return max;
+  }
+  
+  @Override
+  public void incrementNumNulls() {
+    if (this.isEmpty()) {
+      this.markAsNotEmpty();
+    }
+    
+    super.incrementNumNulls();
+  }
+
+  @Override
+  public void incrementNumNulls(long increment) {
+    if (this.isEmpty()) {
+      this.markAsNotEmpty();
+    }
+
+    super.incrementNumNulls(increment);
   }
 
   public int getMax() {
@@ -98,6 +120,7 @@ public class IntStatistics extends Statistics<Integer> {
   public void setMinMax(int min, int max) {
     this.max = max;
     this.min = min;
+    this.markHasValidValue();
     this.markAsNotEmpty();
   }
 }

--- a/parquet-column/src/main/java/parquet/column/statistics/Statistics.java
+++ b/parquet-column/src/main/java/parquet/column/statistics/Statistics.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 public abstract class Statistics<T extends Comparable<T>> {
 
   private boolean firstValueAccountedFor;
+  private boolean containsValidValue;
   private long num_nulls;
 
   public Statistics() {
@@ -142,7 +143,8 @@ public abstract class Statistics<T extends Comparable<T>> {
 
     if (this.getClass() == stats.getClass()) {
       incrementNumNulls(stats.getNumNulls());
-      mergeStatisticsMinMax(stats);
+      if(stats.hasValidValue())
+        mergeStatisticsMinMax(stats);
     } else {
       throw new StatisticsClassException(this.getClass().toString(), stats.getClass().toString());
     }
@@ -185,6 +187,7 @@ public abstract class Statistics<T extends Comparable<T>> {
 
   /**
    * Increments the null count by one
+   * Should call markAsNotEmpty, but called in the derived class
    */
   public void incrementNumNulls() {
     num_nulls++ ;
@@ -193,6 +196,7 @@ public abstract class Statistics<T extends Comparable<T>> {
   /**
    * Increments the null count by the parameter value
    * @param increment value to increment the null count by
+   * Should call markAsNotEmpty, but called in the derived class
    */
   public void incrementNumNulls(long increment) {
     num_nulls += increment ;
@@ -216,7 +220,7 @@ public abstract class Statistics<T extends Comparable<T>> {
 
   /**
    * Returns a boolean specifying if the Statistics object is empty,
-   * i.e does not contain valid statistics for the page/column yet
+   * i.e page/column does not contain any value yet
    * @return true if object is empty, false otherwise
    */
   public boolean isEmpty() {
@@ -226,5 +230,20 @@ public abstract class Statistics<T extends Comparable<T>> {
   protected void markAsNotEmpty() {
     firstValueAccountedFor = true;
   }
+
+  /**
+   * Returns a boolean specifying if the min/max of Statistics
+   * object has a valid value, since it contains non-null
+   * values
+   * @return true if page/column has non-null value, false otherwise
+   */
+  public boolean hasValidValue() {
+    return containsValidValue;
+  }
+
+  protected void markHasValidValue() {
+    containsValidValue = true;
+  }
+
 }
 

--- a/parquet-hadoop/src/main/java/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/parquet/format/converter/ParquetMetadataConverter.java
@@ -234,9 +234,11 @@ public class ParquetMetadataConverter {
   public static Statistics toParquetStatistics(parquet.column.statistics.Statistics statistics) {
     Statistics stats = new Statistics();
     if (!statistics.isEmpty()) {
-      stats.setMax(statistics.getMaxBytes());
-      stats.setMin(statistics.getMinBytes());
       stats.setNull_count(statistics.getNumNulls());
+      if(statistics.hasValidValue()) {
+        stats.setMax(statistics.getMaxBytes());
+        stats.setMin(statistics.getMinBytes());
+     }
     }
     return stats;
   }
@@ -246,7 +248,9 @@ public class ParquetMetadataConverter {
     parquet.column.statistics.Statistics stats = parquet.column.statistics.Statistics.getStatsBasedOnType(type);
     // If there was no statistics written to the footer, create an empty Statistics object and return
     if (statistics != null) {
-      stats.setMinMaxFromBytes(statistics.min.array(), statistics.max.array());
+      if (statistics.isSetMax() && statistics.isSetMin()) {
+        stats.setMinMaxFromBytes(statistics.min.array(), statistics.max.array());
+      }
       stats.setNumNulls(statistics.null_count);
     }
     return stats;


### PR DESCRIPTION
             1. Statistics object should be marked non empty in case null values are written
             2. Keep a boolean in the object to identify presence of non-null values

still to add test cases, verified with spark-sql scenario mentioned in PARQUET-136