### PR TITLE
Parquet 167 - Snappy Compression codec - Optimize freeing of DirectByteBuffers

### DIFF
--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.0.5</version>
+      <version>1.1.1.6</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/SnappyCodec.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/SnappyCodec.java
@@ -15,19 +15,15 @@
  */
 package parquet.hadoop.codec;
 
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.*;
+import parquet.hadoop.codec.buffers.CodecByteBufferFactory;
+import parquet.hadoop.codec.buffers.CodecByteBufferFactory.BuffReuseOpt;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
-import org.apache.hadoop.conf.Configurable;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.compress.CompressionInputStream;
-import org.apache.hadoop.io.compress.CompressionOutputStream;
-import org.apache.hadoop.io.compress.Compressor;
-import org.apache.hadoop.io.compress.Decompressor;
-import parquet.hadoop.codec.buffers.CodecByteBufferFactory;
-import parquet.hadoop.codec.buffers.CodecByteBufferFactory.BufferReuseOption;
 
 /**
  * Snappy compression codec for Parquet.  We do not use the default hadoop
@@ -57,8 +53,8 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   private CodecByteBufferFactory getBufferFactory() {
     // by default maintain the existing behaviour of re-using directByteBuffers
     return conf.getBoolean(SnappyCodec.REUSE_BUFFER_CONFIG, true) ?
-      new CodecByteBufferFactory(BufferReuseOption.ReuseOnReset) :
-      new CodecByteBufferFactory(BufferReuseOption.FreeOnReset);
+      new CodecByteBufferFactory(BuffReuseOpt.ReuseOnReset) :
+      new CodecByteBufferFactory(BuffReuseOpt.FreeOnReset);
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/AbstractCodecByteBuffer.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/AbstractCodecByteBuffer.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.hadoop.codec.buffers;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Base class that implements common functionality around freeing and
+ * allocating bytebuffers
+ */
+public abstract class AbstractCodecByteBuffer implements CodecByteBuffer {
+
+  final public int buffsize;
+
+  protected ByteBuffer buf = null;
+
+  public boolean hasRemaining() {
+    return (buf != null) && (buf.hasRemaining());
+  }
+
+  /**
+   * Explicitly free the off-heap buffer
+   */
+  public void freeBuffer() {
+    if (buf != null) {
+      CodecByteBufferUtil.freeOffHeapBuffer(buf);
+      // The rest will be cleaned up when the buffer object is finalized
+      buf = null;
+    }
+  }
+
+  /**
+   * Allocates a direct byte buffer of the size passed to the constructuor
+   */
+  protected void allocateBuffer()
+  {
+    buf = ByteBuffer.allocateDirect(buffsize);
+  }
+
+  protected AbstractCodecByteBuffer(final int buffsize) {
+    this.buffsize = buffsize;
+  }
+}

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/CodecByteBuffer.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/CodecByteBuffer.java
@@ -1,6 +1,4 @@
 /**
- * Copyright 2012 Twitter, Inc.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,23 +11,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parquet.hadoop.codec;
-
-import parquet.Log;
-import parquet.Preconditions;
-import sun.misc.Cleaner;
-import sun.nio.ch.DirectBuffer;
+package parquet.hadoop.codec.buffers;
 
 import java.nio.ByteBuffer;
 
 /**
- * Utilities for SnappyCompressor and SnappyDecompressor.
+ * Interface abstracts out the difference between reusing the same
+ * byte buffer everytime, or freeing/reallocating the buffer as required
+ * to save on memory overheads (at the cost some cpu overhead)
  */
-public class SnappyUtil {
-  public static void validateBuffer(byte[] buffer, int off, int len) {
-    Preconditions.checkNotNull(buffer, "buffer");
-    Preconditions.checkArgument(off >= 0 && len >= 0 && off <= buffer.length - len,
-        "Invalid offset or length. Out of buffer bounds. buffer.length=" + buffer.length
-        + " off=" + off + " len=" + len);
-  }
+public interface CodecByteBuffer {
+  /**
+   * We do not need the buffer for now, reset it or free it
+   */
+  void resetBuffer();
+
+  /**
+   * Explicitly free the buffer
+   */
+  void freeBuffer();
+
+  /**
+   * Get the underlying ByteBuffer
+   * @return byteBuffer
+   */
+  ByteBuffer get();
 }

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/CodecByteBuffer.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/CodecByteBuffer.java
@@ -1,39 +1,33 @@
-/**
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package parquet.hadoop.codec.buffers;
 
 import java.nio.ByteBuffer;
 
 /**
  * Interface abstracts out the difference between reusing the same
- * byte buffer everytime, or freeing/reallocating the buffer as required
- * to save on memory overheads (at the cost some cpu overhead)
+ * byte buffer every time, and freeing/reallocating the buffer as required
+ * to save on memory overheads (at the cost some cpu overhead for memory allocating)
  */
 public interface CodecByteBuffer {
   /**
-   * We do not need the buffer for now, reset it or free it
+   * Get the underlying ByteBuffer
+   * @return byteBuffer
+   */
+  ByteBuffer get();
+
+  /**
+   * indicate the buffer is not being used anymore
    */
   void resetBuffer();
+
+  /**
+   * Is there any data in the buffer?
+   * @return True if data remains, false otherwise
+   */
+  boolean hasRemaining();
 
   /**
    * Explicitly free the buffer
    */
   void freeBuffer();
 
-  /**
-   * Get the underlying ByteBuffer
-   * @return byteBuffer
-   */
-  ByteBuffer get();
 }

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/CodecByteBufferFactory.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/CodecByteBufferFactory.java
@@ -16,24 +16,37 @@
 package parquet.hadoop.codec.buffers;
 
 /**
- * abstracts out the difference between reusing the same
- * byte buffer everytime, or freeing/reallocating the buffer as required
- * to save on memory overheads (at the cost some cpu overhead)
+ * Factory class that simplifies the creation of the different CodecByteBuffers
  */
 public class CodecByteBufferFactory {
-  public enum BufferReuseOption {
+
+  /**
+   * <li>{@link #ReuseOnReset}</li>*
+   * <li>{@link #FreeOnReset}</li>
+   */
+
+  public enum BuffReuseOpt {
+    /**
+     * Do not free the buffer when it is released, keep
+     * it around and recycle it for the next use
+     */
     ReuseOnReset,
+
+    /**
+     * Immediately free then buffer when it is released
+     * Reallocate a new buffer when it becomes time to use it again
+     */
     FreeOnReset
-  };
+  }
 
-  private final BufferReuseOption bufferReuseOption;
+  private final BuffReuseOpt buffReuseOpt;
 
-  public CodecByteBufferFactory(BufferReuseOption bufferReuseOption) {
-    this.bufferReuseOption = bufferReuseOption;
+  public CodecByteBufferFactory(BuffReuseOpt buffReuseOpt) {
+    this.buffReuseOpt = buffReuseOpt;
   }
 
   public CodecByteBuffer create(int bufsize) {
-    return bufferReuseOption == BufferReuseOption.ReuseOnReset ?
+    return buffReuseOpt == BuffReuseOpt.ReuseOnReset ?
         new ReuseOnResetByteBuffer(bufsize) :
         new FreeOnResetByteBuffer(bufsize);
   }

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/CodecByteBufferFactory.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/CodecByteBufferFactory.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.hadoop.codec.buffers;
+
+/**
+ * abstracts out the difference between reusing the same
+ * byte buffer everytime, or freeing/reallocating the buffer as required
+ * to save on memory overheads (at the cost some cpu overhead)
+ */
+public class CodecByteBufferFactory {
+  public enum BufferReuseOption {
+    ReuseOnReset,
+    FreeOnReset
+  };
+
+  private final BufferReuseOption bufferReuseOption;
+
+  public CodecByteBufferFactory(BufferReuseOption bufferReuseOption) {
+    this.bufferReuseOption = bufferReuseOption;
+  }
+
+  public CodecByteBuffer create(int bufsize) {
+    return bufferReuseOption == BufferReuseOption.ReuseOnReset ?
+        new ReuseOnResetByteBuffer(bufsize) :
+        new FreeOnResetByteBuffer(bufsize);
+  }
+}

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/CodecByteBufferUtil.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/CodecByteBufferUtil.java
@@ -20,13 +20,17 @@ import sun.nio.ch.DirectBuffer;
 import java.nio.ByteBuffer;
 
 /**
- * Util class for manipulating bytebuffer s
+ * Util class for manipulating bytebuffers
  */
 public abstract class CodecByteBufferUtil {
   private static final Log LOG = Log.getLog(CodecByteBufferUtil.class);
 
-  private CodecByteBufferUtil() {};
+  private CodecByteBufferUtil() {}
 
+  /**
+   * Immediately frees the ByteBuffer, not waiting for GC to ocurr.
+   * @param buff Buffer to immediately free
+   */
   public static void freeOffHeapBuffer(ByteBuffer buff) {
     if ((buff != null) && (buff.isDirect())) {
       // even though nio.DirectBuffer is package private, it implements
@@ -42,4 +46,6 @@ public abstract class CodecByteBufferUtil {
       }
     }
   }
+
+
 }

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/CodecByteBufferUtil.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/CodecByteBufferUtil.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.hadoop.codec.buffers;
+
+import parquet.Log;
+import sun.misc.Cleaner;
+import sun.nio.ch.DirectBuffer;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Util class for manipulating bytebuffer s
+ */
+public abstract class CodecByteBufferUtil {
+  private static final Log LOG = Log.getLog(CodecByteBufferUtil.class);
+
+  private CodecByteBufferUtil() {};
+
+  public static void freeOffHeapBuffer(ByteBuffer buff) {
+    if ((buff != null) && (buff.isDirect())) {
+      // even though nio.DirectBuffer is package private, it implements
+      // a public interface (sun.nio.ch.DirectBuffer), so we can cast
+      // our buffer to the interface type to retrieve the cleaner
+      Cleaner cleaner = ((DirectBuffer) buff).cleaner();
+
+      // Forces the immediate release of the off heap buffer
+      if (cleaner != null) {
+        cleaner.clean();
+      } else {
+        LOG.warn("Will have to wait until object is finalized to free off-heap buffer");
+      }
+    }
+  }
+}

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/FreeOnResetByteBuffer.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/FreeOnResetByteBuffer.java
@@ -1,0 +1,61 @@
+package parquet.hadoop.codec.buffers;
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.ByteBuffer;
+
+/**
+ * ByteBuffer wrapper the ensures the directBuffer is freed if it
+ * is not currently being used, and then re-allocated when it is needed
+ */
+public class FreeOnResetByteBuffer implements CodecByteBuffer {
+  private ByteBuffer buf = null;
+  private final int buffsize;
+
+  public FreeOnResetByteBuffer(int buffsize) {
+    this.buffsize = buffsize;
+  }
+
+  private void allocateBuffer()
+  {
+    buf = ByteBuffer.allocateDirect(buffsize);
+  }
+
+  public ByteBuffer get() {
+    if (buf == null) {
+      allocateBuffer();
+    }
+    return buf;
+  }
+
+  /**
+   * If the buffer is no longer needed then immediately free it so the memory
+   * can be used elsewhere
+   */
+  public void resetBuffer() {
+    freeBuffer();
+  }
+
+  /**
+   * Explicitly free the off-heap buffer
+   */
+  public void freeBuffer() {
+    if (buf != null) {
+      CodecByteBufferUtil.freeOffHeapBuffer(buf);
+      // The rest will be cleaned up when the buffer object is finalized
+      buf = null;
+    }
+  }
+
+}

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/FreeOnResetByteBuffer.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/FreeOnResetByteBuffer.java
@@ -19,19 +19,13 @@ import java.nio.ByteBuffer;
  * ByteBuffer wrapper the ensures the directBuffer is freed if it
  * is not currently being used, and then re-allocated when it is needed
  */
-public class FreeOnResetByteBuffer implements CodecByteBuffer {
-  private ByteBuffer buf = null;
-  private final int buffsize;
+public class FreeOnResetByteBuffer extends AbstractCodecByteBuffer {
 
   public FreeOnResetByteBuffer(int buffsize) {
-    this.buffsize = buffsize;
+    super(buffsize);
   }
 
-  private void allocateBuffer()
-  {
-    buf = ByteBuffer.allocateDirect(buffsize);
-  }
-
+  @Override
   public ByteBuffer get() {
     if (buf == null) {
       allocateBuffer();
@@ -39,23 +33,8 @@ public class FreeOnResetByteBuffer implements CodecByteBuffer {
     return buf;
   }
 
-  /**
-   * If the buffer is no longer needed then immediately free it so the memory
-   * can be used elsewhere
-   */
+  @Override
   public void resetBuffer() {
     freeBuffer();
   }
-
-  /**
-   * Explicitly free the off-heap buffer
-   */
-  public void freeBuffer() {
-    if (buf != null) {
-      CodecByteBufferUtil.freeOffHeapBuffer(buf);
-      // The rest will be cleaned up when the buffer object is finalized
-      buf = null;
-    }
-  }
-
 }

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/ReuseOnResetByteBuffer.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/ReuseOnResetByteBuffer.java
@@ -1,0 +1,43 @@
+package parquet.hadoop.codec.buffers;
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.ByteBuffer;
+
+/**
+ * Wrapper around DirectBuffer that implements the default original
+ * behaviour of keeping the bytebuffer allocated even when
+ * we are finished using it so we can reuse it when needed
+ */
+public class ReuseOnResetByteBuffer implements CodecByteBuffer {
+  private ByteBuffer buf;
+  private int buffsize;
+
+  public ReuseOnResetByteBuffer(int buffsize) {
+    buf = ByteBuffer.allocateDirect(buffsize);
+    this.buffsize = buffsize;
+  }
+
+  public ByteBuffer get() { return buf; }
+
+  public void resetBuffer() {
+    buf.rewind();
+    buf.limit(0);
+  }
+
+  public void freeBuffer() {
+    CodecByteBufferUtil.freeOffHeapBuffer(buf);
+    buf = null;
+  }
+}

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/ReuseOnResetByteBuffer.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/buffers/ReuseOnResetByteBuffer.java
@@ -20,24 +20,20 @@ import java.nio.ByteBuffer;
  * behaviour of keeping the bytebuffer allocated even when
  * we are finished using it so we can reuse it when needed
  */
-public class ReuseOnResetByteBuffer implements CodecByteBuffer {
-  private ByteBuffer buf;
-  private int buffsize;
+public class ReuseOnResetByteBuffer extends AbstractCodecByteBuffer {
 
   public ReuseOnResetByteBuffer(int buffsize) {
-    buf = ByteBuffer.allocateDirect(buffsize);
-    this.buffsize = buffsize;
+    super(buffsize);
+    allocateBuffer();
   }
 
+  @Override
   public ByteBuffer get() { return buf; }
 
+  @Override
   public void resetBuffer() {
     buf.rewind();
     buf.limit(0);
   }
 
-  public void freeBuffer() {
-    CodecByteBufferUtil.freeOffHeapBuffer(buf);
-    buf = null;
-  }
 }

--- a/parquet-hadoop/src/test/java/parquet/format/converter/TestParquetMetadataConverter.java
+++ b/parquet-hadoop/src/test/java/parquet/format/converter/TestParquetMetadataConverter.java
@@ -244,7 +244,7 @@ public class TestParquetMetadataConverter {
       try {
         verifyAllFilters(metadata(rgs), splitSize);
       } catch (AssertionError e) {
-	  throw new AssertionError("fail verifyAllFilters(metadata(" + Arrays.toString(rgs) + "), " + splitSize + ")", e);
+	  throw new AssertionError("fail verifyAllFilters(metadata(" + Arrays.toString(rgs) + "), " + splitSize + ")");
       }
     }
   }

--- a/parquet-hadoop/src/test/java/parquet/hadoop/TestSnappyCodec.java
+++ b/parquet-hadoop/src/test/java/parquet/hadoop/TestSnappyCodec.java
@@ -15,23 +15,22 @@
  */
 package parquet.hadoop;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CompressionInputStream;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.junit.Test;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
 import org.xerial.snappy.Snappy;
-
 import parquet.hadoop.codec.SnappyCodec;
 import parquet.hadoop.codec.SnappyCompressor;
 import parquet.hadoop.codec.SnappyDecompressor;
 import parquet.hadoop.codec.buffers.CodecByteBufferFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestSnappyCodec {
 
@@ -40,10 +39,10 @@ public class TestSnappyCodec {
     // Reuse the snappy objects between test cases
     SnappyCompressor compressor = new SnappyCompressor();
     compressor.setByteBufferFactory(new
-        CodecByteBufferFactory(CodecByteBufferFactory.BufferReuseOption.FreeOnReset));
+        CodecByteBufferFactory(CodecByteBufferFactory.BuffReuseOpt.FreeOnReset));
     SnappyDecompressor decompressor = new SnappyDecompressor();
     decompressor.setByteBufferFactory(new
-        CodecByteBufferFactory(CodecByteBufferFactory.BufferReuseOption.ReuseOnReset));
+        CodecByteBufferFactory(CodecByteBufferFactory.BuffReuseOpt.ReuseOnReset));
     TestSnappy(compressor,decompressor);
   }
 
@@ -52,11 +51,11 @@ public class TestSnappyCodec {
     // Reuse the snappy objects between test cases
     SnappyCompressor compressor = new SnappyCompressor();
     compressor.setByteBufferFactory(new
-        CodecByteBufferFactory(CodecByteBufferFactory.BufferReuseOption.ReuseOnReset));
+        CodecByteBufferFactory(CodecByteBufferFactory.BuffReuseOpt.ReuseOnReset));
     SnappyDecompressor decompressor = new SnappyDecompressor();
     decompressor.setByteBufferFactory(new
-        CodecByteBufferFactory(CodecByteBufferFactory.BufferReuseOption.FreeOnReset));
-    TestSnappy(compressor,decompressor);
+        CodecByteBufferFactory(CodecByteBufferFactory.BuffReuseOpt.FreeOnReset));
+    TestSnappyDriver(compressor, decompressor);
   }
 
   public void TestSnappyDriver(SnappyCompressor compressor, SnappyDecompressor decompressor) throws IOException  {

--- a/parquet-hadoop/src/test/java/parquet/hadoop/TestSnappyCodec.java
+++ b/parquet-hadoop/src/test/java/parquet/hadoop/TestSnappyCodec.java
@@ -31,23 +31,45 @@ import org.xerial.snappy.Snappy;
 import parquet.hadoop.codec.SnappyCodec;
 import parquet.hadoop.codec.SnappyCompressor;
 import parquet.hadoop.codec.SnappyDecompressor;
+import parquet.hadoop.codec.buffers.CodecByteBufferFactory;
 
 public class TestSnappyCodec {
+
   @Test
-  public void TestSnappy() throws IOException {
+  public void TestSnappyFreeBuffesToReuseBuffers() throws IOException {
     // Reuse the snappy objects between test cases
     SnappyCompressor compressor = new SnappyCompressor();
+    compressor.setByteBufferFactory(new
+        CodecByteBufferFactory(CodecByteBufferFactory.BufferReuseOption.FreeOnReset));
     SnappyDecompressor decompressor = new SnappyDecompressor();
+    decompressor.setByteBufferFactory(new
+        CodecByteBufferFactory(CodecByteBufferFactory.BufferReuseOption.ReuseOnReset));
+    TestSnappy(compressor,decompressor);
+  }
 
-    TestSnappy(compressor, decompressor, "");    
-    TestSnappy(compressor, decompressor, "FooBar");    
-    TestSnappy(compressor, decompressor, "FooBar1", "FooBar2");    
-    TestSnappy(compressor, decompressor, "FooBar");
-    TestSnappy(compressor, decompressor, "a", "blahblahblah", "abcdef");    
+  @Test
+  public void TestSnappyReuseBuffersToFreeBuffers() throws IOException {
+    // Reuse the snappy objects between test cases
+    SnappyCompressor compressor = new SnappyCompressor();
+    compressor.setByteBufferFactory(new
+        CodecByteBufferFactory(CodecByteBufferFactory.BufferReuseOption.ReuseOnReset));
+    SnappyDecompressor decompressor = new SnappyDecompressor();
+    decompressor.setByteBufferFactory(new
+        CodecByteBufferFactory(CodecByteBufferFactory.BufferReuseOption.FreeOnReset));
+    TestSnappy(compressor,decompressor);
+  }
+
+  public void TestSnappyDriver(SnappyCompressor compressor, SnappyDecompressor decompressor) throws IOException  {
     TestSnappy(compressor, decompressor, "");
     TestSnappy(compressor, decompressor, "FooBar");
+    TestSnappy(compressor, decompressor, "FooBar1", "FooBar2");
+    TestSnappy(compressor, decompressor, "FooBar");
+    TestSnappy(compressor, decompressor, "a", "blahblahblah", "abcdef");
+    TestSnappy(compressor, decompressor, "");
+    TestSnappy(compressor, decompressor, "FooBar", "Apache Parquet is a columnar storage format available to any project" +
+        "in the Hadoop ecosystem, regardless of the choice of data processing framework, data model or programming language.");
   }
-  
+
   @Test
   public void TestSnappyStream() throws IOException {
     SnappyCodec codec = new SnappyCodec();


### PR DESCRIPTION
This PR changes the memory handling of the Snappy codec, by allowing the codec to explicitly free memory when no longer required.

Freeing of DirectByteBuffers is usually performed by GC routines calling the 'cleaner' routine registered for the buffer.  We can access the same routines by:
a. Utilising the sun proprietry api java.nio.ByteBuffer interface to access the cleaner routine
b. Using reflection to access the routine.
In this PR, option (a) was used as it was considered the cleaner/more performant approach.

Given the capability to explicitly free DirectByteBuffers, the snappy codec was changed so that when DirectByteBuffers are being replaced with larger buffers, the old buffers are explicitly freed rather then waiting for GC to free them.

Optional behaviour was added controlled by the configuration option: ''org.apache.hadoop.io.compress.SnappyCodec.keepBuffersForReuse" (defaults to true).
If this option is true, then the existing snappy codec memory use behaviour of keeping buffers available continues to occur.

If this option if false, then a new behaviour occurs that frees buffers once the snappy codec has finished with them, and reallocates the buffers when required again.  Some overhead is expected for this, but should be negligible versus the cost of disk IO.

A new interface (parquet.hadoop.codec.buffers.CodecByteBuffer) has been added to abstract out the difference between these two options.  The module includes associated implementations and a factory object.
