### PR TITLE
PARQUET-173: Fixes `StatisticsFilter` for `And` filter predicate

### DIFF
--- a/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
+++ b/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
@@ -224,7 +224,11 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
 
   @Override
   public Boolean visit(And and) {
-    return and.getLeft().accept(this) && and.getRight().accept(this);
+    // seems unintuitive to put an || not an && here but we can
+    // drop a chunk of records if we know that either the left or
+    // the right predicate agrees that no matter what we don't
+    // need this chunk.
+    return and.getLeft().accept(this) || and.getRight().accept(this);
   }
 
   @Override

--- a/parquet-hadoop/src/test/java/parquet/filter2/statisticslevel/TestStatisticsFilter.java
+++ b/parquet-hadoop/src/test/java/parquet/filter2/statisticslevel/TestStatisticsFilter.java
@@ -204,8 +204,8 @@ public class TestStatisticsFilter {
     FilterPredicate yes = eq(intColumn, 9);
     FilterPredicate no = eq(doubleColumn, 50D);
     assertTrue(canDrop(and(yes, yes), columnMetas));
-    assertFalse(canDrop(and(yes, no), columnMetas));
-    assertFalse(canDrop(and(no, yes), columnMetas));
+    assertTrue(canDrop(and(yes, no), columnMetas));
+    assertTrue(canDrop(and(no, yes), columnMetas));
     assertFalse(canDrop(and(no, no), columnMetas));
   }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/incubator-parquet-mr/108)
<!-- Reviewable:end -->
