### PR TITLE
PARQUET-187: Replace JavaConversions.asJavaList with JavaConversions.seqAsJavaList

### DIFF
--- a/parquet-scrooge/src/main/java/parquet/scrooge/ScroogeStructConverter.java
+++ b/parquet-scrooge/src/main/java/parquet/scrooge/ScroogeStructConverter.java
@@ -286,7 +286,7 @@ public class ScroogeStructConverter {
     Object cObject = companionObjectClass.getField("MODULE$").get(null);
     Method listMethod = companionObjectClass.getMethod("list", new Class[]{});
     Object result = listMethod.invoke(cObject, null);
-    return JavaConversions.asJavaList((Seq)result);
+    return JavaConversions.seqAsJavaList((Seq)result);
   }
 
   public ThriftType convertEnumTypeField(ThriftStructFieldInfo f) {


### PR DESCRIPTION
The former was removed in 2.11, but the latter exists in 2.9, 2.10 and 2.11. With this change, I can build on 2.11 without any issue.