### PR TITLE
PARQUET-162: ParquetThrift should throw when unrecognized columns are passed to the column projection API

### DIFF
--- a/parquet-thrift/src/main/java/parquet/thrift/ThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/main/java/parquet/thrift/ThriftSchemaConvertVisitor.java
@@ -56,6 +56,10 @@ import parquet.thrift.struct.ThriftType;
  */
 public class ThriftSchemaConvertVisitor implements ThriftType.TypeVisitor {
 
+  public FieldProjectionFilter getFieldProjectionFilter() {
+    return fieldProjectionFilter;
+  }
+
   FieldProjectionFilter fieldProjectionFilter;
   Type currentType;
   FieldsPath currentFieldPath = new FieldsPath();

--- a/parquet-thrift/src/main/java/parquet/thrift/ThriftSchemaConverter.java
+++ b/parquet-thrift/src/main/java/parquet/thrift/ThriftSchemaConverter.java
@@ -22,8 +22,7 @@ import com.twitter.elephantbird.thrift.TStructDescriptor;
 import com.twitter.elephantbird.thrift.TStructDescriptor.Field;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TEnum;
-import parquet.ParquetRuntimeException;
-import parquet.schema.*;
+import parquet.schema.MessageType;
 import parquet.thrift.projection.FieldProjectionFilter;
 import parquet.thrift.projection.PathGlobPattern;
 import parquet.thrift.projection.ThriftProjectionException;
@@ -65,9 +64,9 @@ public class ThriftSchemaConverter {
     return convertedMessageType;
   }
 
-  private void checkUnmatchedProjectionFilter(FieldProjectionFilter filter){
+  private void checkUnmatchedProjectionFilter(FieldProjectionFilter filter) {
     List<PathGlobPattern> unmatched = filter.getUnMatchedPatterns();
-    if (unmatched.size()!=0) {
+    if (unmatched.size() != 0) {
       throw new ThriftProjectionException("unmatched projection filters: " + unmatched.toString());
     }
   }

--- a/parquet-thrift/src/main/java/parquet/thrift/projection/FieldProjectionFilter.java
+++ b/parquet-thrift/src/main/java/parquet/thrift/projection/FieldProjectionFilter.java
@@ -34,7 +34,7 @@ public class FieldProjectionFilter {
    * Class for remembering if a glob pattern has matched anything.
    * If there is an invalid glob pattern that matches nothing, it should throw.
    */
-  private class PathGlobPatternStatus {
+  private static class PathGlobPatternStatus {
     PathGlobPattern pattern;
     boolean hasMatchingPath = false;
 

--- a/parquet-thrift/src/main/java/parquet/thrift/projection/FieldProjectionFilter.java
+++ b/parquet-thrift/src/main/java/parquet/thrift/projection/FieldProjectionFilter.java
@@ -34,18 +34,19 @@ public class FieldProjectionFilter {
    * Class for remembering if a glob pattern has matched anything.
    * If there is an invalid glob pattern that matches nothing, it should throw.
    */
-  private class PathGlobPatternStatus{
+  private class PathGlobPatternStatus {
     PathGlobPattern pattern;
     boolean hasMatchingPath = false;
-    PathGlobPatternStatus(String pattern){
-      this.pattern =new PathGlobPattern(pattern);
+
+    PathGlobPatternStatus(String pattern) {
+      this.pattern = new PathGlobPattern(pattern);
     }
 
     public boolean matches(FieldsPath path) {
       if (this.pattern.matches(path.toString())) {
         this.hasMatchingPath = true;
         return true;
-      }else{
+      } else {
         return false;
       }
     }
@@ -81,7 +82,7 @@ public class FieldProjectionFilter {
 
   public List<PathGlobPattern> getUnMatchedPatterns() {
     List<PathGlobPattern> unmatched = new LinkedList<PathGlobPattern>();
-    for(PathGlobPatternStatus p : filterPatterns) {
+    for (PathGlobPatternStatus p : filterPatterns) {
       if (!p.hasMatchingPath) {
         unmatched.add(p.pattern);
       }

--- a/parquet-thrift/src/main/java/parquet/thrift/projection/PathGlobPattern.java
+++ b/parquet-thrift/src/main/java/parquet/thrift/projection/PathGlobPattern.java
@@ -170,6 +170,11 @@ public class PathGlobPattern {
     compiled = Pattern.compile(regex.toString());
   }
 
+  @Override
+  public String toString() {
+    return compiled.toString();
+  }
+
   /**
    * @return true if this is a wildcard pattern (with special chars)
    */

--- a/parquet-thrift/src/test/java/parquet/thrift/TestThriftSchemaConverter.java
+++ b/parquet-thrift/src/test/java/parquet/thrift/TestThriftSchemaConverter.java
@@ -19,6 +19,7 @@
 package parquet.thrift;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static parquet.schema.MessageTypeParser.parseMessageType;
 
 import org.apache.thrift.TBase;
@@ -200,6 +201,17 @@ public class TestThriftSchemaConverter {
             "    }\n" +
             "  }\n" +
             "}",TestStructInMap.class);
+  }
+
+  @Test
+  public void testThrowWhenProjectionFilterMatchesNothing() {
+    try {
+      getFilteredSchema("non_existing_path", TestStructInMap.class);
+    } catch (ThriftProjectionException e) {
+      assertEquals("unmatched projection filters: [non_existing_path]", e.getMessage());
+      return;
+    }
+    fail("should throw projection exception when filter matches nothing");
   }
 
   @Test(expected = ThriftProjectionException.class)

--- a/parquet-thrift/src/test/java/parquet/thrift/TestThriftSchemaConverter.java
+++ b/parquet-thrift/src/test/java/parquet/thrift/TestThriftSchemaConverter.java
@@ -203,15 +203,23 @@ public class TestThriftSchemaConverter {
             "}",TestStructInMap.class);
   }
 
-  @Test
-  public void testThrowWhenProjectionFilterMatchesNothing() {
+
+  private void shouldThrowWhenProjectionFilterMatchesNothing(String filters, String unmatchedFilter, Class<? extends TBase<?, ?>> thriftClass) {
     try {
-      getFilteredSchema("non_existing_path", TestStructInMap.class);
+      getFilteredSchema(filters, thriftClass);
     } catch (ThriftProjectionException e) {
-      assertEquals("unmatched projection filters: [non_existing_path]", e.getMessage());
+      assertEquals("unmatched projection filters: [" + unmatchedFilter + "]", e.getMessage());
       return;
     }
     fail("should throw projection exception when filter matches nothing");
+  }
+
+  @Test
+  public void testThrowWhenProjectionFilterMatchesNothing() {
+    shouldThrowWhenProjectionFilterMatchesNothing("non_existing", "non_existing", TestStructInMap.class);
+    shouldThrowWhenProjectionFilterMatchesNothing("name;non_existing", "non_existing", TestStructInMap.class);
+    shouldThrowWhenProjectionFilterMatchesNothing("**;non_existing", "non_existing", TestStructInMap.class);
+    shouldThrowWhenProjectionFilterMatchesNothing("**;names/non_existing", "names/non_existing", TestStructInMap.class);
   }
 
   @Test(expected = ThriftProjectionException.class)

--- a/parquet-thrift/src/test/java/parquet/thrift/TestThriftSchemaConverter.java
+++ b/parquet-thrift/src/test/java/parquet/thrift/TestThriftSchemaConverter.java
@@ -224,7 +224,7 @@ public class TestThriftSchemaConverter {
 
   @Test(expected = ThriftProjectionException.class)
   public void testProjectOnlyValueInMap() {
-    System.out.println(getFilteredSchema("name;names/value/**", TestStructInMap.class));
+    getFilteredSchema("name;names/value/**", TestStructInMap.class);
   }
 
   private void shouldGetProjectedSchema(String filterDesc, String expectedSchemaStr, Class<? extends TBase<?,?>> thriftClass) {
@@ -238,13 +238,11 @@ public class TestThriftSchemaConverter {
     return new ThriftSchemaConverter(fieldProjectionFilter).convert(thriftClass);
   }
 
-
   @Test
   public void testToThriftType() throws Exception {
     ThriftSchemaConverter schemaConverter = new ThriftSchemaConverter();
     final StructType converted = schemaConverter.toStructType(AddressBook.class);
     final String json = converted.toJSON();
-    System.out.println(json);
     final ThriftType fromJSON = StructType.fromJSON(json);
     assertEquals(json, fromJSON.toJSON());
   }

--- a/parquet-thrift/src/test/java/parquet/thrift/TestThriftSchemaConverter.java
+++ b/parquet-thrift/src/test/java/parquet/thrift/TestThriftSchemaConverter.java
@@ -220,6 +220,7 @@ public class TestThriftSchemaConverter {
     shouldThrowWhenProjectionFilterMatchesNothing("name;non_existing", "non_existing", TestStructInMap.class);
     shouldThrowWhenProjectionFilterMatchesNothing("**;non_existing", "non_existing", TestStructInMap.class);
     shouldThrowWhenProjectionFilterMatchesNothing("**;names/non_existing", "names/non_existing", TestStructInMap.class);
+    shouldThrowWhenProjectionFilterMatchesNothing("**;names/non_existing;non_existing", "names/non_existing, non_existing", TestStructInMap.class);
   }
 
   @Test(expected = ThriftProjectionException.class)


### PR DESCRIPTION
ParquetThrift should throw when unrecognized columns are passed to the column projection API