### PR TITLE
PARQUET-189:Support building parquet with thrift 0.9.0

### DIFF
--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -115,6 +115,12 @@
       <version>3.4</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${thrift.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
     <scala.maven.test.skip>false</scala.maven.test.skip>
     <pig.version>0.11.1</pig.version>
     <pig.classifier></pig.classifier>
+    <thrift.version>0.7.0</thrift.version>
   </properties>
 
   <modules>
@@ -534,6 +535,12 @@
         <hadoop.version>2.3.0</hadoop.version>
         <pig.version>0.13.0</pig.version>
         <pig.classifier>h2</pig.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>thrift9</id>
+      <properties>
+        <thrift.version>0.9.0</thrift.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Summary:
   add one profile to enable thrift with version 0.9.0