### PR TITLE
PARQUET-197 : fix parquet-cascading not writing parquet metadata file

### DIFF
--- a/parquet-cascading/src/main/java/parquet/cascading/ParquetTBaseScheme.java
+++ b/parquet-cascading/src/main/java/parquet/cascading/ParquetTBaseScheme.java
@@ -28,7 +28,6 @@ import cascading.tap.Tap;
 import parquet.filter2.predicate.FilterPredicate;
 import parquet.hadoop.ParquetInputFormat;
 import parquet.hadoop.mapred.DeprecatedParquetInputFormat;
-import parquet.hadoop.mapred.DeprecatedParquetOutputCommitter;
 import parquet.hadoop.mapred.DeprecatedParquetOutputFormat;
 import parquet.hadoop.thrift.ThriftReadSupport;
 import parquet.hadoop.thrift.TBaseWriteSupport;
@@ -74,8 +73,7 @@ public class ParquetTBaseScheme<T extends TBase<?,?>> extends ParquetValueScheme
       throw new IllegalArgumentException("To use ParquetTBaseScheme as a sink, you must specify a thrift class in the constructor");
     }
 
-    jobConf.setOutputFormat(DeprecatedParquetOutputFormat.class);
-    jobConf.setOutputCommitter(DeprecatedParquetOutputCommitter.class);
+    DeprecatedParquetOutputFormat.setAsOutputFormat(jobConf);
     DeprecatedParquetOutputFormat.setWriteSupportClass(jobConf, TBaseWriteSupport.class);
     TBaseWriteSupport.<T>setThriftClass(jobConf, this.config.getKlass());
   }

--- a/parquet-cascading/src/main/java/parquet/cascading/ParquetTBaseScheme.java
+++ b/parquet-cascading/src/main/java/parquet/cascading/ParquetTBaseScheme.java
@@ -28,6 +28,7 @@ import cascading.tap.Tap;
 import parquet.filter2.predicate.FilterPredicate;
 import parquet.hadoop.ParquetInputFormat;
 import parquet.hadoop.mapred.DeprecatedParquetInputFormat;
+import parquet.hadoop.mapred.DeprecatedParquetOutputCommitter;
 import parquet.hadoop.mapred.DeprecatedParquetOutputFormat;
 import parquet.hadoop.thrift.ThriftReadSupport;
 import parquet.hadoop.thrift.TBaseWriteSupport;
@@ -74,6 +75,7 @@ public class ParquetTBaseScheme<T extends TBase<?,?>> extends ParquetValueScheme
     }
 
     jobConf.setOutputFormat(DeprecatedParquetOutputFormat.class);
+    jobConf.setOutputCommitter(DeprecatedParquetOutputCommitter.class);
     DeprecatedParquetOutputFormat.setWriteSupportClass(jobConf, TBaseWriteSupport.class);
     TBaseWriteSupport.<T>setThriftClass(jobConf, this.config.getKlass());
   }

--- a/parquet-cascading/src/main/java/parquet/cascading/ParquetTupleScheme.java
+++ b/parquet-cascading/src/main/java/parquet/cascading/ParquetTupleScheme.java
@@ -171,7 +171,7 @@ public class ParquetTupleScheme extends Scheme<JobConf, RecordReader, OutputColl
   @Override
   public void sinkConfInit(FlowProcess<JobConf> fp,
           Tap<JobConf, RecordReader, OutputCollector> tap, JobConf jobConf) {
-    jobConf.setOutputFormat(DeprecatedParquetOutputFormat.class);
+    DeprecatedParquetOutputFormat.setAsOutputFormat(jobConf);
     jobConf.set(TupleWriteSupport.PARQUET_CASCADING_SCHEMA, parquetSchema);
     ParquetOutputFormat.setWriteSupportClass(jobConf, TupleWriteSupport.class);
   }

--- a/parquet-cascading/src/test/java/parquet/cascading/TestParquetTBaseScheme.java
+++ b/parquet-cascading/src/test/java/parquet/cascading/TestParquetTBaseScheme.java
@@ -78,6 +78,9 @@ public class TestParquetTBaseScheme {
     Flow flow  = new HadoopFlowConnector().connect("namecp", source, sink, assembly);
 
     flow.complete();
+    assertTrue(fs.exists(new Path(parquetOutputPath)));
+    assertTrue(fs.exists(new Path(parquetOutputPath + "/_metadata")));
+    assertTrue(fs.exists(new Path(parquetOutputPath + "/_common_metadata")));
   }
 
   @Test

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetOutputCommitter.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetOutputCommitter.java
@@ -45,6 +45,10 @@ public class ParquetOutputCommitter extends FileOutputCommitter {
   public void commitJob(JobContext jobContext) throws IOException {
     super.commitJob(jobContext);
     Configuration configuration = ContextUtil.getConfiguration(jobContext);
+    writeMetaDataFile(configuration,outputPath);
+  }
+
+  public static void writeMetaDataFile(Configuration configuration, Path outputPath) {
     if (configuration.getBoolean(ParquetOutputFormat.ENABLE_JOB_SUMMARY, true)) {
       try {
         final FileSystem fileSystem = outputPath.getFileSystem(configuration);

--- a/parquet-hadoop/src/main/java/parquet/hadoop/mapred/DeprecatedParquetOutputCommitter.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/mapred/DeprecatedParquetOutputCommitter.java
@@ -1,0 +1,23 @@
+package parquet.hadoop.mapred;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.*;
+import parquet.hadoop.ParquetOutputCommitter;
+
+import java.io.IOException;
+
+/**
+ *
+ * Adapter for supporting ParquetOutputCommitter in mapred API
+ *
+ * @author Tianshuo Deng
+ */
+public class DeprecatedParquetOutputCommitter extends FileOutputCommitter {
+
+  @Override
+  public void commitJob(JobContext jobContext) throws IOException {
+    JobConf jobConf = jobContext.getJobConf();
+    Path outputPath = FileOutputFormat.getOutputPath(jobConf);
+    ParquetOutputCommitter.writeMetaDataFile(jobConf, outputPath);
+  }
+}

--- a/parquet-hadoop/src/main/java/parquet/hadoop/mapred/DeprecatedParquetOutputCommitter.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/mapred/DeprecatedParquetOutputCommitter.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package parquet.hadoop.mapred;
 
 import org.apache.hadoop.fs.Path;

--- a/parquet-hadoop/src/main/java/parquet/hadoop/mapred/DeprecatedParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/mapred/DeprecatedParquetOutputFormat.java
@@ -55,6 +55,11 @@ public class DeprecatedParquetOutputFormat<V> extends org.apache.hadoop.mapred.F
     configuration.setBoolean(ParquetOutputFormat.ENABLE_DICTIONARY, enableDictionary);
   }
 
+  public static void setAsOutputFormat(JobConf jobConf) {
+    jobConf.setOutputFormat(DeprecatedParquetOutputFormat.class);
+    jobConf.setOutputCommitter(MapredParquetOutputCommitter.class);
+  }
+
   private CompressionCodecName getCodec(final JobConf conf) {
     return CodecConfig.from(conf).getCodec();
   }

--- a/parquet-hadoop/src/main/java/parquet/hadoop/mapred/MapredParquetOutputCommitter.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/mapred/MapredParquetOutputCommitter.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  *
  * @author Tianshuo Deng
  */
-public class DeprecatedParquetOutputCommitter extends FileOutputCommitter {
+public class MapredParquetOutputCommitter extends FileOutputCommitter {
 
   @Override
   public void commitJob(JobContext jobContext) throws IOException {

--- a/parquet-scrooge/src/main/java/parquet/scrooge/ParquetScroogeScheme.java
+++ b/parquet-scrooge/src/main/java/parquet/scrooge/ParquetScroogeScheme.java
@@ -18,8 +18,6 @@
  */
 package parquet.scrooge;
 
-import java.io.IOException;
-
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.RecordReader;
@@ -27,7 +25,6 @@ import org.apache.hadoop.mapred.RecordReader;
 import com.twitter.scrooge.ThriftStruct;
 
 import cascading.flow.FlowProcess;
-import cascading.scheme.SinkCall;
 import cascading.tap.Tap;
 import parquet.cascading.ParquetValueScheme;
 import parquet.filter2.predicate.FilterPredicate;
@@ -56,7 +53,7 @@ public class ParquetScroogeScheme<T extends ThriftStruct> extends ParquetValueSc
   @Override
   public void sinkConfInit(FlowProcess<JobConf> fp,
       Tap<JobConf, RecordReader, OutputCollector> tap, JobConf jobConf) {
-    jobConf.setOutputFormat(DeprecatedParquetOutputFormat.class);
+    DeprecatedParquetOutputFormat.setAsOutputFormat(jobConf);
     ParquetOutputFormat.setWriteSupportClass(jobConf, ScroogeWriteSupport.class);
     ScroogeWriteSupport.setScroogeClass(jobConf, this.config.getKlass());
   }


### PR DESCRIPTION
Repro: run a scalding job that writes parquet files to a folder. no _metadata and _common_metadata file is created
Impact: potential performance problem if parquet metadata is read from client side, which is the case for sparkSQL
casue: the metatdata writing logic is in the mapreduce API but not the mapred API of parquet.