### PR TITLE
PARQUET-210: add JSON support for parquet-cat

### DIFF
--- a/parquet-tools/src/main/java/parquet/tools/command/CatCommand.java
+++ b/parquet-tools/src/main/java/parquet/tools/command/CatCommand.java
@@ -18,6 +18,9 @@ package parquet.tools.command;
 import java.io.PrintWriter;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Options;
 import org.apache.hadoop.fs.Path;
 
 import parquet.hadoop.ParquetReader;
@@ -31,6 +34,15 @@ public class CatCommand extends ArgsOnlyCommand {
     "where <input> is the parquet file to print to stdout"
   };
 
+  public static final Options OPTIONS;
+  static {
+    OPTIONS = new Options();
+    Option help = OptionBuilder.withLongOpt("json")
+                               .withDescription("Show records in JSON format.")
+                               .create('j');
+    OPTIONS.addOption(help);
+  }
+
   public CatCommand() {
     super(1, 1);
   }
@@ -38,6 +50,11 @@ public class CatCommand extends ArgsOnlyCommand {
   @Override
   public String[] getUsageDescription() {
     return USAGE;
+  }
+
+  @Override
+  public Options getOptions() {
+    return OPTIONS;
   }
 
   @Override
@@ -52,7 +69,11 @@ public class CatCommand extends ArgsOnlyCommand {
       PrintWriter writer = new PrintWriter(Main.out, true);
       reader = new ParquetReader<SimpleRecord>(new Path(input), new SimpleReadSupport());
       for (SimpleRecord value = reader.read(); value != null; value = reader.read()) {
-        value.prettyPrint(writer);
+        if (options.hasOption('j')) {
+          value.prettyPrintJson(writer);
+        } else {
+          value.prettyPrint(writer);
+        }
         writer.println();
       }
     } finally {

--- a/parquet-tools/src/main/java/parquet/tools/read/SimpleListRecord.java
+++ b/parquet-tools/src/main/java/parquet/tools/read/SimpleListRecord.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package parquet.tools.read;
+
+public class SimpleListRecord extends SimpleRecord {
+  @Override
+  protected Object toJsonObject() {
+    Object[] result = new Object[values.size()];
+    for (int i = 0; i < values.size(); i++) {
+      result[i] = toJsonValue(values.get(i).getValue());
+    }
+    return result;
+  }
+}

--- a/parquet-tools/src/main/java/parquet/tools/read/SimpleListRecordConverter.java
+++ b/parquet-tools/src/main/java/parquet/tools/read/SimpleListRecordConverter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package parquet.tools.read;
+
+import parquet.schema.GroupType;
+
+public class SimpleListRecordConverter extends SimpleRecordConverter {
+
+  public SimpleListRecordConverter(GroupType schema, String name, SimpleRecordConverter parent) {
+    super(schema, name, parent);
+  }
+
+  @Override
+  public void start() {
+    record = new SimpleListRecord();
+  }
+
+}

--- a/parquet-tools/src/main/java/parquet/tools/read/SimpleMapRecord.java
+++ b/parquet-tools/src/main/java/parquet/tools/read/SimpleMapRecord.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package parquet.tools.read;
+
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+public class SimpleMapRecord extends SimpleRecord {
+  @Override
+  protected Object toJsonObject() {
+    Map<String, Object> result = Maps.newLinkedHashMap();
+    for (NameValue value : values) {
+      String key = null;
+      Object val = null;
+      for (NameValue kv : ((SimpleRecord) value.getValue()).values) {
+        if (kv.getName().equals("key")) {
+          key = (String) kv.getValue();
+        } else if (kv.getName().equals("value")) {
+          val = toJsonValue(kv.getValue());
+        }
+      }
+      result.put(key, val);
+    }
+    return result;
+  }
+}

--- a/parquet-tools/src/main/java/parquet/tools/read/SimpleMapRecordConverter.java
+++ b/parquet-tools/src/main/java/parquet/tools/read/SimpleMapRecordConverter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package parquet.tools.read;
+
+import parquet.schema.GroupType;
+
+public class SimpleMapRecordConverter extends SimpleRecordConverter {
+
+  public SimpleMapRecordConverter(GroupType schema, String name, SimpleRecordConverter parent) {
+    super(schema, name, parent);
+  }
+
+  @Override
+  public void start() {
+    record = new SimpleMapRecord();
+  }
+
+}

--- a/parquet-tools/src/main/java/parquet/tools/read/SimpleRecordConverter.java
+++ b/parquet-tools/src/main/java/parquet/tools/read/SimpleRecordConverter.java
@@ -15,12 +15,10 @@
  */
 package parquet.tools.read;
 
-import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 
-import parquet.column.Dictionary;
 import parquet.io.api.Binary;
 import parquet.io.api.Converter;
 import parquet.io.api.GroupConverter;
@@ -41,7 +39,7 @@ public class SimpleRecordConverter extends GroupConverter {
   private final Converter converters[];
   private final String name;
   private final SimpleRecordConverter parent;
-  private SimpleRecord record;
+  protected SimpleRecord record;
 
   public SimpleRecordConverter(GroupType schema) {
     this(schema, null, null);
@@ -59,8 +57,9 @@ public class SimpleRecordConverter extends GroupConverter {
   }
 
   private Converter createConverter(Type field) {
+    OriginalType otype = field.getOriginalType();
+
     if (field.isPrimitive()) {
-      OriginalType otype = field.getOriginalType();
       if (otype != null) {
         switch (otype) {
           case MAP: break;
@@ -74,7 +73,14 @@ public class SimpleRecordConverter extends GroupConverter {
       return new SimplePrimitiveConverter(field.getName());
     }
 
-    return new SimpleRecordConverter(field.asGroupType(), field.getName(), this);
+    GroupType groupType = field.asGroupType();
+    if (otype != null) {
+      switch (otype) {
+        case MAP: return new SimpleMapRecordConverter(groupType, field.getName(), this);
+        case LIST: return new SimpleListRecordConverter(groupType, field.getName(), this);
+      }
+    }
+    return new SimpleRecordConverter(groupType, field.getName(), this);
   }
 
   @Override
@@ -107,21 +113,6 @@ public class SimpleRecordConverter extends GroupConverter {
 
     @Override
     public void addBinary(Binary value) {
-      byte[] data = value.getBytes();
-      if (data == null) {
-        record.add(name, null);
-        return;
-      }
-
-      if (data != null) {
-        try {
-          CharBuffer buffer = UTF8_DECODER.decode(value.toByteBuffer());
-          record.add(name, buffer.toString());
-          return;
-        } catch (Throwable th) {
-        }
-      }
-
       record.add(name, value.getBytes());
     }
 


### PR DESCRIPTION
JSON output with this patch:
```
{"int_field":99,"long_field":1099,"float_field":2099.5,"double_field":5099.5,"boolean_field":true,"string_field":"str99","nested":{"numbers":[100,101,102,103,104],"name":"name99","dict":{"a":100,"b":200,"c":300}}}
```

Current output format:
```
int_field = 99
long_field = 1099
float_field = 2099.5
double_field = 5099.5
boolean_field = true
string_field = str99
nested:
.numbers:
..array = 100
..array = 101
..array = 102
..array = 103
..array = 104
.name = name99
.dict:
..map:
...key = a
...value = 100
..map:
...key = b
...value = 200
..map:
...key = c
...value = 300
```