### PR TITLE
PARQUET-217 Use simpler heuristic in MemoryManager

### DIFF
--- a/parquet-hadoop/src/main/java/parquet/hadoop/MemoryManager.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/MemoryManager.java
@@ -122,8 +122,8 @@ public class MemoryManager {
     for (Map.Entry<InternalParquetRecordWriter, Long> entry : writerList.entrySet()) {
       long newSize = (long) Math.floor(entry.getValue() * scale);
       if(scale < 1.0 && minMemoryAllocation > 0 && newSize < minMemoryAllocation) {
-          throw new ParquetRuntimeException(String.format("New Memory allocation %d" +
-          " is smaller than the minimum allocation size of %d",
+          throw new ParquetRuntimeException(String.format("New Memory allocation %d bytes" +
+          " is smaller than the minimum allocation size of %d bytes.",
               newSize, minMemoryAllocation)){};
       }
       entry.getKey().setRowGroupSizeThreshold(newSize);

--- a/parquet-hadoop/src/main/java/parquet/hadoop/MemoryManager.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/MemoryManager.java
@@ -40,7 +40,7 @@ import java.util.Map;
 public class MemoryManager {
   private static final Log LOG = Log.getLog(MemoryManager.class);
   static final float DEFAULT_MEMORY_POOL_RATIO = 0.95f;
-  static final long DEFAULT_MIN_MEMORY_ALLOCATION = ParquetWriter.DEFAULT_PAGE_SIZE;
+  static final long DEFAULT_MIN_MEMORY_ALLOCATION = 1 * 1024 * 1024; // 1MB
   private final float memoryPoolRatio;
 
   private final long totalMemoryPool;

--- a/parquet-hadoop/src/main/java/parquet/hadoop/MemoryManager.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/MemoryManager.java
@@ -40,27 +40,39 @@ import java.util.Map;
 public class MemoryManager {
   private static final Log LOG = Log.getLog(MemoryManager.class);
   static final float DEFAULT_MEMORY_POOL_RATIO = 0.95f;
-  static final long DEFAULT_MIN_MEMORY_ALLOCATION = ParquetWriter.DEFAULT_PAGE_SIZE;
+  static final float DEFAULT_MIN_SCALE = 0.25f;
   private final float memoryPoolRatio;
 
   private final long totalMemoryPool;
   private final long minMemoryAllocation;
+  private final float minScale;
   private final Map<InternalParquetRecordWriter, Long> writerList = new
       HashMap<InternalParquetRecordWriter, Long>();
 
-  public MemoryManager(float ratio, long minAllocation) {
-    checkRatio(ratio);
+  public MemoryManager(float ratio, float minScale) {
+    this(ratio, -1, minScale);
+  }
 
-    memoryPoolRatio = ratio;
-    minMemoryAllocation = minAllocation;
-    totalMemoryPool = Math.round(ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax
-        () * ratio);
+  @Deprecated
+  public MemoryManager(float ratio, long minAllocation) {
+    this(ratio, minAllocation, DEFAULT_MIN_SCALE);
+  }
+
+  @Deprecated
+  MemoryManager(float ratio, long minAllocation, float minScale) {
+    checkRatio(ratio, "memory pool ratio");
+    checkRatio(minScale, "min scale");
+
+    this.memoryPoolRatio = ratio;
+    this.minMemoryAllocation = minAllocation;
+    this.minScale = minScale;
+    totalMemoryPool = Math.round(ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax() * ratio);
     LOG.debug(String.format("Allocated total memory pool is: %,d", totalMemoryPool));
   }
 
-  private void checkRatio(float ratio) {
+  private void checkRatio(float ratio, String name) {
     if (ratio <= 0 || ratio > 1) {
-      throw new IllegalArgumentException("The configured memory pool ratio " + ratio + " is " +
+      throw new IllegalArgumentException("The configured " + name + " " + ratio + " is " +
           "not between 0 and 1.");
     }
   }
@@ -108,6 +120,12 @@ public class MemoryManager {
       scale = 1.0;
     } else {
       scale = (double) totalMemoryPool / totalAllocations;
+      if (scale < this.minScale) {
+        throw new ParquetRuntimeException(
+            "Attempting to scale column chunks to " + scale*100 + "% of their original size, which is less than"
+            + "the configured min scale of " + minScale*100 + "%"){};
+      }
+
       LOG.warn(String.format(
           "Total allocation exceeds %.2f%% (%,d bytes) of heap memory\n" +
           "Scaling row group sizes to %.2f%% for %d writers",
@@ -121,6 +139,11 @@ public class MemoryManager {
 
     for (Map.Entry<InternalParquetRecordWriter, Long> entry : writerList.entrySet()) {
       long newSize = (long) Math.floor(entry.getValue() * scale);
+
+      // This check is deprecated, and is only enabled when minMemoryAllocation > 0
+      // which only happens when the deprecated constructor is used.
+      // This heuristic is not valid for schemas with a large number of sparsely populated
+      // columns.
       if(minMemoryAllocation > 0 && newSize/maxColCount < minMemoryAllocation) {
           throw new ParquetRuntimeException(String.format("New Memory allocation %d"+
           " exceeds minimum allocation size %d with largest schema having %d columns",

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetOutputFormat.java
@@ -108,10 +108,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static final String WRITER_VERSION       = "parquet.writer.version";
   public static final String ENABLE_JOB_SUMMARY   = "parquet.enable.summary-metadata";
   public static final String MEMORY_POOL_RATIO    = "parquet.memory.pool.ratio";
-  @Deprecated
   public static final String MIN_MEMORY_ALLOCATION = "parquet.memory.min.chunk.size";
-
-  public static final String MIN_MEMORY_MANAGER_SCALE = "parquet.memory.min.scale.size";
 
   public static void setWriteSupportClass(Job job,  Class<?> writeSupportClass) {
     getConfiguration(job).set(WRITE_SUPPORT_CLASS, writeSupportClass.getName());
@@ -294,17 +291,10 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
 
     float maxLoad = conf.getFloat(ParquetOutputFormat.MEMORY_POOL_RATIO,
         MemoryManager.DEFAULT_MEMORY_POOL_RATIO);
-
-    long minAllocation = conf.getLong(ParquetOutputFormat.MIN_MEMORY_ALLOCATION, -1);
-
-    float minScale = conf.getFloat(ParquetOutputFormat.MIN_MEMORY_MANAGER_SCALE, MemoryManager.DEFAULT_MIN_SCALE);
-
+    long minAllocation = conf.getLong(ParquetOutputFormat.MIN_MEMORY_ALLOCATION,
+        MemoryManager.DEFAULT_MIN_MEMORY_ALLOCATION);
     if (memoryManager == null) {
-      if (minAllocation > 0) {
-        LOG.warn(ParquetOutputFormat.MIN_MEMORY_ALLOCATION + " is deprecated in favor of "
-            + ParquetOutputFormat.MIN_MEMORY_MANAGER_SCALE);
-      }
-      memoryManager = new MemoryManager(maxLoad, minAllocation, minScale);
+      memoryManager = new MemoryManager(maxLoad, minAllocation);
     } else if (memoryManager.getMemoryPoolRatio() != maxLoad) {
       LOG.warn("The configuration " + MEMORY_POOL_RATIO + " has been set. It should not " +
           "be reset by the new value: " + maxLoad);

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetOutputFormat.java
@@ -108,7 +108,10 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static final String WRITER_VERSION       = "parquet.writer.version";
   public static final String ENABLE_JOB_SUMMARY   = "parquet.enable.summary-metadata";
   public static final String MEMORY_POOL_RATIO    = "parquet.memory.pool.ratio";
+  @Deprecated
   public static final String MIN_MEMORY_ALLOCATION = "parquet.memory.min.chunk.size";
+
+  public static final String MIN_MEMORY_MANAGER_SCALE = "parquet.memory.min.scale.size";
 
   public static void setWriteSupportClass(Job job,  Class<?> writeSupportClass) {
     getConfiguration(job).set(WRITE_SUPPORT_CLASS, writeSupportClass.getName());
@@ -291,10 +294,17 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
 
     float maxLoad = conf.getFloat(ParquetOutputFormat.MEMORY_POOL_RATIO,
         MemoryManager.DEFAULT_MEMORY_POOL_RATIO);
-    long minAllocation = conf.getLong(ParquetOutputFormat.MIN_MEMORY_ALLOCATION,
-        MemoryManager.DEFAULT_MIN_MEMORY_ALLOCATION);
+
+    long minAllocation = conf.getLong(ParquetOutputFormat.MIN_MEMORY_ALLOCATION, -1);
+
+    float minScale = conf.getFloat(ParquetOutputFormat.MIN_MEMORY_MANAGER_SCALE, MemoryManager.DEFAULT_MIN_SCALE);
+
     if (memoryManager == null) {
-      memoryManager = new MemoryManager(maxLoad, minAllocation);
+      if (minAllocation > 0) {
+        LOG.warn(ParquetOutputFormat.MIN_MEMORY_ALLOCATION + " is deprecated in favor of "
+            + ParquetOutputFormat.MIN_MEMORY_MANAGER_SCALE);
+      }
+      memoryManager = new MemoryManager(maxLoad, minAllocation, minScale);
     } else if (memoryManager.getMemoryPoolRatio() != maxLoad) {
       LOG.warn("The configuration " + MEMORY_POOL_RATIO + " has been set. It should not " +
           "be reset by the new value: " + maxLoad);


### PR DESCRIPTION
We found that the heuristic of throwing when:
```
minMemoryAllocation > 0 && newSize/maxColCount < minMemoryAllocation
```
in MemoryManager is not really valid when you have many (3k +) columns, due to the division by the number of columns.
This check throws immediately when writing a single file with a 3GB heap and > 3K columns.

This PR introduces a simpler heuristic, which is a min scale, and we throw when the MemoryManager's scale gets too small. By default I chose 25%, but I'm happy to change that to something else.

For backwards compatibility I've left the original check in, but it's not executed by default anymore, to get this behavior the min chunk size will have to be set in the hadoop configuration. I'm also open to removing it entirely if we don't think we need it anymore.

What do you think?
@danielcweeks @rdblue @dongche @julienledem