### PR TITLE
[PARQUET-198] Initial commit of ParquetAvroScheme (WIP)

### DIFF
--- a/parquet-avro/src/main/java/parquet/avro/projection/AvroCustomField.java
+++ b/parquet-avro/src/main/java/parquet/avro/projection/AvroCustomField.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package parquet.avro.projection;
+
+import org.apache.avro.Schema;
+
+//remember the original field position
+public class AvroCustomField extends Schema.Field {
+    Schema schema;
+    Schema.Field field;
+
+    public AvroCustomField(Schema schema, Schema.Field field) {
+        super(field.name(), schema, field.doc(), field.defaultValue());
+        this.schema = schema;
+        this.field = field;
+    }
+
+    public int pos() {
+        return field.pos();
+    }
+
+}

--- a/parquet-avro/src/main/java/parquet/avro/projection/AvroProjection.java
+++ b/parquet-avro/src/main/java/parquet/avro/projection/AvroProjection.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package parquet.avro.projection;
+
+import org.apache.avro.Schema;
+import  org.apache.avro.Schema.Type.*;
+
+import java.util.*;
+
+// originally based on https://raw.githubusercontent.com/epishkin/scalding/parquet_avro/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/avro/Projection.scala
+
+/**
+ * Helps create projections for Avro schemas.
+ */
+public class AvroProjection {
+    /**
+     * Create a projection for {{schema}} that includes {{fields}}.
+     */
+    public static Schema createProjection(Schema schema, String[] fields)  {
+        return createProjection(schema, fields, null);
+    }
+
+
+    private static Schema createProjection(Schema schema, String[] fields, String parentFieldName) {
+        switch(schema.getType()) {
+            case RECORD:
+                return createRecordProjection(schema, fields, parentFieldName);
+            case UNION:
+                return createUnionProjection(schema, fields, parentFieldName);
+            case ARRAY:
+                return createArrayProjection(schema, fields, parentFieldName);
+            default:
+                String fieldInfo = schema.getType().toString();
+                if (parentFieldName != null) {
+                    fieldInfo = parentFieldName + fieldInfo;
+                }
+                String children = convertFieldNamesToString(fields);
+                throw new RuntimeException("Projection doesn't support schema type " + fieldInfo + " with fields: " + children);
+        }
+    }
+
+    private static Schema createRecordProjection(Schema schema, String[] fields, String parentFieldName) {
+        // Take the head of any nested properties, "parent.fieldX" => "parent"
+        List<String> nestedFields = new LinkedList<String>();
+        for (int i = 0; i < fields.length; i++) {
+            if (fields[i].contains(".")) {
+                nestedFields.add(fields[i].split("\\.")[0]);
+            }
+        }
+        List<String> directFields = new LinkedList<String>();
+        Collections.copy(directFields, nestedFields);
+        directFields.addAll(Arrays.asList(fields));
+
+        List<Schema.Field> schemaFields = schema.getFields();
+        validateRequestedFields(schema, schemaFields, directFields);
+
+        List<Schema.Field> projectedFields = new LinkedList<Schema.Field>();
+
+        for (Schema.Field field : schemaFields) {
+            if (directFields.contains(field.name())) {
+                Schema thisSchema;
+                // Create projection for the nested field
+                if (nestedFields.contains(field.name())) {
+                    String prefix = field.name() + ".";
+                    // Find the nested fields and remove the prefix
+                    List<String> children = new LinkedList<String>();
+                    for (String requestedField : fields) {
+                        if (requestedField.startsWith(prefix)) {
+                            children.add(requestedField.substring(0, prefix.length()));
+                        }
+                    }
+                    thisSchema = createProjection(field.schema(), (String[])children.toArray(), fullFieldName(parentFieldName, field.name()));
+                } else {
+                    thisSchema = field.schema();
+                }
+
+                projectedFields.add(copyField(thisSchema, field));
+            }
+        }
+
+        Schema projection = Schema.createRecord(schema.getName(), schema.getDoc(), schema.getNamespace(), false);
+        projection.setFields(projectedFields);
+        return projection;
+    }
+
+    private static Schema createUnionProjection(Schema schema, String[] fields, String parentFieldName) {
+        List<Schema> projectedSchemas = new LinkedList<Schema>();
+        for (Schema nestedSchema : schema.getTypes()) {
+            if (nestedSchema.getType() == Schema.Type.NULL) {
+                projectedSchemas.add(nestedSchema);
+            } else {
+                projectedSchemas.add(createProjection(nestedSchema, fields, parentFieldName));
+            }
+        }
+        return Schema.createUnion(projectedSchemas);
+    }
+
+    private static Schema createArrayProjection(Schema schema, String[] fields, String parentFieldName) {
+        return Schema.createArray(
+                createProjection(schema.getElementType(), fields, parentFieldName));
+    }
+
+    private static void validateRequestedFields(Schema schema, List<Schema.Field> schemaFields, List<String> fieldNames) throws RuntimeException {
+        Set<String> schemaFieldNames = new HashSet<String>();
+        for (Schema.Field field: schemaFields) {
+            schemaFieldNames.add(field.name());
+        }
+        for (String field: fieldNames) {
+            if (!field.contains("\\.") && !schemaFieldNames.contains(field)) {
+                String full_name = schema.getFullName();
+                final String supported_fields = Arrays.toString(schemaFieldNames.toArray());
+                throw new RuntimeException(
+                        "Field " + field + " not found in schema " + full_name + ". " +
+                                "Supported fields are: " + supported_fields
+                );
+            }
+        }
+    }
+
+    private static Schema.Field copyField(Schema schema, Schema.Field field) {
+        return (new AvroCustomField(schema, field));
+    }
+
+    private static String fullFieldName(String parentFieldName, String fieldName) {
+        if (parentFieldName == null) {
+            return null;
+        } else {
+            return (parentFieldName + "." + fieldName);
+        }
+    }
+
+    private static String convertFieldNamesToString(String[] fields) {
+        StringBuilder sb = new StringBuilder();
+        for (String field : fields) {
+            if (sb.length() > 0) sb.append(", ");
+            sb.append(field);
+        }
+        return sb.toString();
+    }
+
+}

--- a/parquet-cascading/pom.xml
+++ b/parquet-cascading/pom.xml
@@ -55,6 +55,11 @@
         <artifactId>parquet-thrift</artifactId>
         <version>${project.version}</version>
     </dependency>
+      <dependency>
+          <groupId>com.twitter</groupId>
+          <artifactId>parquet-avro</artifactId>
+          <version>${project.version}</version>
+      </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
@@ -113,6 +118,23 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-maven-plugin</artifactId>
+        <version>1.7.6</version>
+        <executions>
+          <execution>
+            <phase>generate-test-sources</phase>
+            <goals>
+               <goal>idl-protocol</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${project.basedir}/src/test/avro/</sourceDirectory>
+              <!-- <outputDirectory>${project.basedir}/src/test/java/</outputDirectory> -->
+      </configuration>
+    </execution>
+  </executions>
       </plugin>
     </plugins>
   </build>

--- a/parquet-cascading/src/main/java/parquet/cascading/ParquetAvroScheme.java
+++ b/parquet-cascading/src/main/java/parquet/cascading/ParquetAvroScheme.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package parquet.cascading;
+
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.hadoop.mapred.RecordReader;
+
+import cascading.flow.FlowProcess;
+import cascading.tap.Tap;
+import parquet.avro.AvroReadSupport;
+import parquet.avro.AvroWriteSupport;
+import parquet.avro.projection.AvroProjection;
+import parquet.filter2.predicate.FilterPredicate;
+import parquet.hadoop.ParquetInputFormat;
+import parquet.hadoop.mapred.DeprecatedParquetInputFormat;
+import parquet.hadoop.mapred.DeprecatedParquetOutputFormat;
+import parquet.hadoop.metadata.CompressionCodecName;
+
+public class ParquetAvroScheme<T extends IndexedRecord> extends ParquetValueScheme<T> {
+
+  // In the case of reads, we can read the thrift class from the file metadata
+  public ParquetAvroScheme() {
+    this(new parquet.cascading.ParquetValueScheme.Config<T>());
+  }
+
+  public ParquetAvroScheme(Class<T> avroClass) {
+    this(new parquet.cascading.ParquetValueScheme.Config<T>().withRecordClass(avroClass));
+  }
+
+  public ParquetAvroScheme(FilterPredicate filterPredicate) {
+    this(new parquet.cascading.ParquetValueScheme.Config<T>().withFilterPredicate(filterPredicate));
+  }
+
+  public ParquetAvroScheme(FilterPredicate filterPredicate, Class<T> avroClass) {
+    this(new parquet.cascading.ParquetValueScheme.Config<T>().withRecordClass(avroClass).withFilterPredicate(filterPredicate));
+  }
+
+  public ParquetAvroScheme(parquet.cascading.ParquetValueScheme.Config<T> config) {
+    super(config);
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public void sourceConfInit(FlowProcess<JobConf> fp,
+      Tap<JobConf, RecordReader, OutputCollector> tap, JobConf jobConf) {
+    super.sourceConfInit(fp, tap, jobConf);
+    try {
+        jobConf.setInputFormat(DeprecatedParquetInputFormat.class);
+        IndexedRecord record = (IndexedRecord)config.getKlass().getConstructor(null).newInstance(null);
+        ParquetInputFormat.setReadSupportClass(jobConf, AvroReadSupport.class);
+        AvroReadSupport.setAvroReadSchema(jobConf, record.getSchema());
+        AvroReadSupport.setRequestedProjection(jobConf, AvroProjection.createProjection(record.getSchema(), config.getProjectionString().split(";")));
+        ParquetInputFormat.setFilterPredicate(jobConf, config.getFilterPredicate());
+    } catch (Exception e) {
+        System.err.println(e.toString());
+    }
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public void sinkConfInit(FlowProcess<JobConf> fp,
+      Tap<JobConf, RecordReader, OutputCollector> tap, JobConf jobConf) {
+
+      if (this.config.getKlass() == null) {
+          throw new IllegalArgumentException("To use ParquetAvroScheme as a sink, you must specify an avro class in the constructor");
+      }
+
+      try {
+          jobConf.setOutputFormat(DeprecatedParquetOutputFormat.class);
+          DeprecatedParquetOutputFormat.setWriteSupportClass(jobConf, AvroWriteSupport.class);
+          DeprecatedParquetOutputFormat.setCompressOutput(jobConf, true);
+          DeprecatedParquetOutputFormat.setCompression(jobConf, CompressionCodecName.SNAPPY);
+          IndexedRecord record = (IndexedRecord)config.getKlass().getConstructor(null).newInstance(null);
+          AvroWriteSupport.setSchema(jobConf, record.getSchema());
+      } catch (Exception e) {
+          System.err.println(e.toString());
+      }
+  }
+}
+

--- a/parquet-cascading/src/test/avro/test.avdl
+++ b/parquet-cascading/src/test/avro/test.avdl
@@ -1,0 +1,8 @@
+@namespace("avrotestclasses")
+protocol AvroTest {
+    record Name {
+        string first_name;
+        // optional last name
+        union { null, string } last_name = null;
+    }
+}

--- a/parquet-cascading/src/test/java/parquet/cascading/TestParquetAvroScheme.java
+++ b/parquet-cascading/src/test/java/parquet/cascading/TestParquetAvroScheme.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package parquet.cascading;
+
+import cascading.flow.Flow;
+import cascading.flow.FlowProcess;
+import cascading.flow.hadoop.HadoopFlowConnector;
+import cascading.operation.BaseOperation;
+import cascading.operation.Function;
+import cascading.operation.FunctionCall;
+import cascading.pipe.Each;
+import cascading.pipe.Pipe;
+import cascading.scheme.Scheme;
+import cascading.scheme.hadoop.TextLine;
+import cascading.tap.Tap;
+import cascading.tap.hadoop.Hfs;
+import cascading.tuple.Fields;
+import cascading.tuple.Tuple;
+import cascading.tuple.TupleEntry;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.junit.Test;
+import parquet.avro.AvroParquetWriter;
+import parquet.hadoop.metadata.CompressionCodecName;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import avrotestclasses.Name;
+
+/**
+ * Created by schuman on 23/03/15.
+ */
+public class TestParquetAvroScheme {
+    final String txtInputPath = "src/test/resources/names.txt";
+    final String parquetInputPath = "target/test/ParquetAvroScheme/names-parquet-in";
+    final String parquetOutputPath = "target/test/ParquetAvroScheme/names-parquet-out";
+    final String txtOutputPath = "target/test/ParquetAvroScheme/names-txt-out";
+
+    @Test
+    public void testWrite() throws Exception {
+        Path path = new Path(parquetOutputPath);
+        JobConf jobConf = new JobConf();
+        final FileSystem fs = path.getFileSystem(jobConf);
+        if (fs.exists(path)) fs.delete(path, true);
+
+        Scheme sourceScheme = new TextLine( new Fields( "first", "last" ) );
+        Tap source = new Hfs(sourceScheme, txtInputPath);
+
+        Scheme sinkScheme = new ParquetAvroScheme(Name.class);
+        Tap sink = new Hfs(sinkScheme, parquetOutputPath);
+
+        Pipe assembly = new Pipe( "namecp" );
+        assembly = new Each(assembly, new PackAvroFunction());
+        HadoopFlowConnector hadoopFlowConnector = new HadoopFlowConnector();
+        Flow flow  = hadoopFlowConnector.connect("namecp", source, sink, assembly);
+
+        flow.complete();
+
+        assertTrue(fs.exists(new Path(parquetOutputPath)));
+        assertTrue(fs.exists(new Path(parquetOutputPath + "/_SUCCESS")));
+    }
+
+    @Test
+    public void testRead() throws Exception {
+        doRead(new ParquetAvroScheme(Name.class));
+    }
+
+    /*@Test
+    // TODO: make scheme work without requiring code generation
+    public void testReadWithoutClass() throws Exception {
+        doRead(new ParquetAvroScheme(GenericRecord.class));
+    }*/
+
+    private void doRead(Scheme sourceScheme) throws Exception {
+        createFileForRead();
+
+        Path path = new Path(txtOutputPath);
+        final FileSystem fs = path.getFileSystem(new Configuration());
+        if (fs.exists(path)) fs.delete(path, true);
+
+        Tap source = new Hfs(sourceScheme, parquetInputPath);
+
+        Scheme sinkScheme = new TextLine(new Fields("first", "last"));
+        Tap sink = new Hfs(sinkScheme, txtOutputPath);
+
+        Pipe assembly = new Pipe( "namecp" );
+        assembly = new Each(assembly, new UnpackAvroFunction());
+        Flow flow  = new HadoopFlowConnector().connect("namecp", source, sink, assembly);
+
+        flow.complete();
+        String result = FileUtils.readFileToString(new File(txtOutputPath + "/part-00000"));
+        assertEquals("Alice\tPractice\nBob\tHope\nCharlie\tHorse\n", result);
+    }
+
+
+    private void createFileForRead() throws Exception {
+        final Path fileToCreate = new Path(parquetInputPath+"/names.parquet");
+
+        final Configuration conf = new Configuration();
+        final FileSystem fs = fileToCreate.getFileSystem(conf);
+        if (fs.exists(fileToCreate)) fs.delete(fileToCreate, true);
+
+        AvroParquetWriter writer = new AvroParquetWriter(fileToCreate, Name.getClassSchema(), CompressionCodecName.UNCOMPRESSED, 100, 100);
+        Name n1 = new Name();
+        n1.setFirstName("Alice");
+        n1.setLastName("Practice");
+        Name n2 = new Name();
+        n2.setFirstName("Bob");
+        n2.setLastName("Hope");
+        Name n3 = new Name();
+        n3.setFirstName("Charlie");
+        n3.setLastName("Horse");
+
+        writer.write(n1);
+        writer.write(n2);
+        writer.write(n3);
+        writer.close();
+    }
+
+    private static class PackAvroFunction extends BaseOperation implements Function {
+        @Override
+        public void operate(FlowProcess flowProcess, FunctionCall functionCall) {
+            TupleEntry arguments = functionCall.getArguments();
+            Tuple result = new Tuple();
+
+            Name name = new Name();
+            name.setFirstName(arguments.getString(0));
+            name.setLastName(arguments.getString(1));
+
+            result.add(name);
+            functionCall.getOutputCollector().add(result);
+        }
+    }
+
+    private static class UnpackAvroFunction extends BaseOperation implements Function {
+        @Override
+        public void operate(FlowProcess flowProcess, FunctionCall functionCall) {
+            TupleEntry arguments = functionCall.getArguments();
+            Tuple result = new Tuple();
+
+            Name name = (Name) arguments.get(0);
+            result.add(name.getFirstName());
+            result.add(name.getLastName());
+            functionCall.getOutputCollector().add(result);
+        }
+    }
+}


### PR DESCRIPTION
This is a first attempt of adding a ParquetAvroScheme to parquet-cascading that can be used to read and write Avro records from Parquet files (say, from within Scalding). The code draws heavily on the Thrift implementation of the respective classes.

Currently only code-generated Avro classes are supported.

This code is also partly based on the work done here: https://github.com/epishkin/scalding/tree/parquet_avro/scalding-parquet