### PR TITLE
PARQUET-226: Introduce an interface for controlling the encoding per column and builders for ParquetWriter

### DIFF
--- a/parquet-avro/src/main/java/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroWriteSupport.java
@@ -41,7 +41,7 @@ import parquet.schema.Type;
  * Users should use {@link AvroParquetWriter} or {@link AvroParquetOutputFormat} rather than using
  * this class directly.
  */
-public class AvroWriteSupport extends WriteSupport<IndexedRecord> {
+public class AvroWriteSupport<T extends IndexedRecord> extends WriteSupport<T> {
 
   static final String AVRO_SCHEMA = "parquet.avro.schema";
   private static final Schema MAP_KEY_SCHEMA = Schema.create(Schema.Type.STRING);
@@ -118,12 +118,12 @@ public class AvroWriteSupport extends WriteSupport<IndexedRecord> {
     }
   }
 
-  private <T> void writeArray(GroupType schema, Schema avroSchema,
-                              Collection<T> array) {
+  private <TT> void writeArray(GroupType schema, Schema avroSchema,
+                              Collection<TT> array) {
     recordConsumer.startGroup(); // group wrapper (original type LIST)
     if (array.size() > 0) {
       recordConsumer.startField("array", 0);
-      for (T elt : array) {
+      for (TT elt : array) {
         writeValue(schema.getType(0), avroSchema.getElementType(), elt);
       }
       recordConsumer.endField("array", 0);

--- a/parquet-column/src/main/java/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/parquet/column/ParquetProperties.java
@@ -71,9 +71,9 @@ public class ParquetProperties {
       return WriterVersion.valueOf(name);
     }
   }
-  private final int dictionaryPageSizeThreshold;
-  private final WriterVersion writerVersion;
-  private final boolean enableDictionary;
+  protected final int dictionaryPageSizeThreshold;
+  protected final WriterVersion writerVersion;
+  protected final boolean enableDictionary;
 
   public ParquetProperties(int dictPageSize, WriterVersion writerVersion, boolean enableDict) {
     this.dictionaryPageSizeThreshold = dictPageSize;
@@ -81,7 +81,7 @@ public class ParquetProperties {
     this.enableDictionary = enableDict;
   }
 
-  public static ValuesWriter getColumnDescriptorValuesWriter(int maxLevel, int initialSizePerCol, int pageSize) {
+  public ValuesWriter getColumnDescriptorValuesWriter(int maxLevel, int initialSizePerCol, int pageSize) {
     if (maxLevel == 0) {
       return new DevNullValuesWriter();
     } else {
@@ -206,18 +206,6 @@ public class ParquetProperties {
     }
   }
 
-  public int getDictionaryPageSizeThreshold() {
-    return dictionaryPageSizeThreshold;
-  }
-
-  public WriterVersion getWriterVersion() {
-    return writerVersion;
-  }
-
-  public boolean isEnableDictionary() {
-    return enableDictionary;
-  }
-
   public ColumnWriteStore newColumnWriteStore(
       MessageType schema,
       PageWriteStore pageStore,
@@ -228,13 +216,15 @@ public class ParquetProperties {
           pageStore,
           pageSize,
           dictionaryPageSizeThreshold,
-          enableDictionary, writerVersion);
+          enableDictionary,
+          writerVersion,
+          this);
     case PARQUET_2_0:
       return new ColumnWriteStoreV2(
           schema,
           pageStore,
           pageSize,
-          new ParquetProperties(dictionaryPageSizeThreshold, writerVersion, enableDictionary));
+          this);
     default:
       throw new IllegalArgumentException("unknown version " + writerVersion);
     }

--- a/parquet-column/src/main/java/parquet/column/impl/ColumnWriteStoreV1.java
+++ b/parquet-column/src/main/java/parquet/column/impl/ColumnWriteStoreV1.java
@@ -28,6 +28,7 @@ import java.util.TreeMap;
 import parquet.column.ColumnDescriptor;
 import parquet.column.ColumnWriteStore;
 import parquet.column.ColumnWriter;
+import parquet.column.ParquetProperties;
 import parquet.column.ParquetProperties.WriterVersion;
 import parquet.column.page.PageWriteStore;
 import parquet.column.page.PageWriter;
@@ -40,14 +41,16 @@ public class ColumnWriteStoreV1 implements ColumnWriteStore {
   private final int dictionaryPageSizeThreshold;
   private final boolean enableDictionary;
   private final WriterVersion writerVersion;
+  private final ParquetProperties parquetProps;
 
-  public ColumnWriteStoreV1(PageWriteStore pageWriteStore, int pageSizeThreshold, int dictionaryPageSizeThreshold, boolean enableDictionary, WriterVersion writerVersion) {
+  public ColumnWriteStoreV1(PageWriteStore pageWriteStore, int pageSizeThreshold, int dictionaryPageSizeThreshold, boolean enableDictionary, WriterVersion writerVersion, ParquetProperties parquetProps) {
     super();
     this.pageWriteStore = pageWriteStore;
     this.pageSizeThreshold = pageSizeThreshold;
     this.dictionaryPageSizeThreshold = dictionaryPageSizeThreshold;
     this.enableDictionary = enableDictionary;
     this.writerVersion = writerVersion;
+    this.parquetProps = parquetProps;
   }
 
   public ColumnWriter getColumnWriter(ColumnDescriptor path) {
@@ -65,7 +68,7 @@ public class ColumnWriteStoreV1 implements ColumnWriteStore {
 
   private ColumnWriterV1 newMemColumn(ColumnDescriptor path) {
     PageWriter pageWriter = pageWriteStore.getPageWriter(path);
-    return new ColumnWriterV1(path, pageWriter, pageSizeThreshold, dictionaryPageSizeThreshold, enableDictionary, writerVersion);
+    return new ColumnWriterV1(path, pageWriter, pageSizeThreshold, dictionaryPageSizeThreshold, enableDictionary, writerVersion, parquetProps);
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/column/impl/ColumnWriterV1.java
+++ b/parquet-column/src/main/java/parquet/column/impl/ColumnWriterV1.java
@@ -67,7 +67,8 @@ final class ColumnWriterV1 implements ColumnWriter {
       int pageSizeThreshold,
       int dictionaryPageSizeThreshold,
       boolean enableDictionary,
-      WriterVersion writerVersion) {
+      WriterVersion writerVersion,
+      ParquetProperties parquetProps) {
     this.path = path;
     this.pageWriter = pageWriter;
     this.pageSizeThreshold = pageSizeThreshold;
@@ -75,10 +76,8 @@ final class ColumnWriterV1 implements ColumnWriter {
     this.valueCountForNextSizeCheck = INITIAL_COUNT_FOR_SIZE_CHECK;
     resetStatistics();
 
-    ParquetProperties parquetProps = new ParquetProperties(dictionaryPageSizeThreshold, writerVersion, enableDictionary);
-
-    this.repetitionLevelColumn = ParquetProperties.getColumnDescriptorValuesWriter(path.getMaxRepetitionLevel(), MIN_SLAB_SIZE, pageSizeThreshold);
-    this.definitionLevelColumn = ParquetProperties.getColumnDescriptorValuesWriter(path.getMaxDefinitionLevel(), MIN_SLAB_SIZE, pageSizeThreshold);
+    this.repetitionLevelColumn = parquetProps.getColumnDescriptorValuesWriter(path.getMaxRepetitionLevel(), MIN_SLAB_SIZE, pageSizeThreshold);
+    this.definitionLevelColumn = parquetProps.getColumnDescriptorValuesWriter(path.getMaxDefinitionLevel(), MIN_SLAB_SIZE, pageSizeThreshold);
 
     int initialSlabSize = CapacityByteArrayOutputStream.initialSlabSizeHeuristic(MIN_SLAB_SIZE, pageSizeThreshold, 10);
     this.dataColumn = parquetProps.getValuesWriter(path, initialSlabSize, pageSizeThreshold);

--- a/parquet-column/src/test/java/parquet/column/mem/TestMemColumn.java
+++ b/parquet-column/src/test/java/parquet/column/mem/TestMemColumn.java
@@ -26,6 +26,7 @@ import parquet.Log;
 import parquet.column.ColumnDescriptor;
 import parquet.column.ColumnReader;
 import parquet.column.ColumnWriter;
+import parquet.column.ParquetProperties;
 import parquet.column.ParquetProperties.WriterVersion;
 import parquet.column.impl.ColumnReadStoreImpl;
 import parquet.column.impl.ColumnWriteStoreV1;
@@ -159,6 +160,7 @@ public class TestMemColumn {
   }
 
   private ColumnWriteStoreV1 newColumnWriteStoreImpl(MemPageStore memPageStore) {
-    return new ColumnWriteStoreV1(memPageStore, 2048, 2048, false, WriterVersion.PARQUET_1_0);
+    return new ColumnWriteStoreV1(memPageStore, 2048, 2048, false, WriterVersion.PARQUET_1_0,
+        new ParquetProperties(2048, WriterVersion.PARQUET_1_0, false));
   }
 }

--- a/parquet-column/src/test/java/parquet/io/PerfTest.java
+++ b/parquet-column/src/test/java/parquet/io/PerfTest.java
@@ -27,6 +27,7 @@ import static parquet.example.Paper.schema3;
 import java.util.logging.Level;
 
 import parquet.Log;
+import parquet.column.ParquetProperties;
 import parquet.column.ParquetProperties.WriterVersion;
 import parquet.column.impl.ColumnWriteStoreV1;
 import parquet.column.page.mem.MemPageStore;
@@ -77,7 +78,10 @@ public class PerfTest {
 
 
   private static void write(MemPageStore memPageStore) {
-    ColumnWriteStoreV1 columns = new ColumnWriteStoreV1(memPageStore, 50*1024*1024, 50*1024*1024, false, WriterVersion.PARQUET_1_0);
+    ColumnWriteStoreV1 columns =
+        new ColumnWriteStoreV1(memPageStore, 50 * 1024 * 1024, 50 * 1024 * 1024, false,
+            WriterVersion.PARQUET_1_0, new ParquetProperties(50 * 1024 * 1024,
+                WriterVersion.PARQUET_1_0, false));
     MessageColumnIO columnIO = newColumnFactory(schema);
 
     GroupWriter groupWriter = new GroupWriter(columnIO.getRecordWriter(columns), schema);

--- a/parquet-column/src/test/java/parquet/io/TestColumnIO.java
+++ b/parquet-column/src/test/java/parquet/io/TestColumnIO.java
@@ -47,6 +47,7 @@ import parquet.Log;
 import parquet.column.ColumnDescriptor;
 import parquet.column.ColumnWriteStore;
 import parquet.column.ColumnWriter;
+import parquet.column.ParquetProperties;
 import parquet.column.ParquetProperties.WriterVersion;
 import parquet.column.impl.ColumnWriteStoreV1;
 import parquet.column.page.PageReadStore;
@@ -517,7 +518,8 @@ public class TestColumnIO {
   }
 
   private ColumnWriteStoreV1 newColumnWriteStore(MemPageStore memPageStore) {
-    return new ColumnWriteStoreV1(memPageStore, 800, 800, useDictionary, WriterVersion.PARQUET_1_0);
+    return new ColumnWriteStoreV1(memPageStore, 800, 800, useDictionary, WriterVersion.PARQUET_1_0,
+        new ParquetProperties(800, WriterVersion.PARQUET_1_0, useDictionary));
   }
 
   @Test

--- a/parquet-column/src/test/java/parquet/io/TestFiltered.java
+++ b/parquet-column/src/test/java/parquet/io/TestFiltered.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import parquet.column.ParquetProperties;
 import parquet.column.ParquetProperties.WriterVersion;
 import parquet.column.impl.ColumnWriteStoreV1;
 import parquet.column.page.mem.MemPageStore;
@@ -33,7 +34,6 @@ import parquet.filter.ColumnPredicates.LongPredicateFunction;
 import parquet.filter.ColumnPredicates.PredicateFunction;
 import parquet.filter2.compat.FilterCompat;
 import parquet.io.api.RecordMaterializer;
-
 import static org.junit.Assert.assertEquals;
 import static parquet.example.Paper.r1;
 import static parquet.example.Paper.r2;
@@ -257,7 +257,9 @@ public class TestFiltered {
 
   private MemPageStore writeTestRecords(MessageColumnIO columnIO, int number) {
     MemPageStore memPageStore = new MemPageStore(number * 2);
-    ColumnWriteStoreV1 columns = new ColumnWriteStoreV1(memPageStore, 800, 800, false, WriterVersion.PARQUET_1_0);
+    ColumnWriteStoreV1 columns =
+        new ColumnWriteStoreV1(memPageStore, 800, 800, false, WriterVersion.PARQUET_1_0,
+            new ParquetProperties(800, WriterVersion.PARQUET_1_0, false));
 
     GroupWriter groupWriter = new GroupWriter(columnIO.getRecordWriter(columns), schema);
     for ( int i = 0; i < number; i++ ) {

--- a/parquet-hadoop/src/main/java/parquet/hadoop/InternalParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/InternalParquetRecordWriter.java
@@ -85,7 +85,8 @@ class InternalParquetRecordWriter<T> {
       int dictionaryPageSize,
       boolean enableDictionary,
       boolean validating,
-      WriterVersion writerVersion) {
+      WriterVersion writerVersion,
+      ParquetProperties parquetProps) {
     this.parquetFileWriter = parquetFileWriter;
     this.writeSupport = checkNotNull(writeSupport, "writeSupport");
     this.schema = schema;
@@ -95,7 +96,7 @@ class InternalParquetRecordWriter<T> {
     this.pageSize = pageSize;
     this.compressor = compressor;
     this.validating = validating;
-    this.parquetProperties = new ParquetProperties(dictionaryPageSize, writerVersion, enableDictionary);
+    this.parquetProperties = parquetProps;
     initStore();
   }
 

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetRecordWriter.java
@@ -20,14 +20,15 @@ package parquet.hadoop;
 
 import java.io.IOException;
 import java.util.Map;
+
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
+import parquet.column.ParquetProperties;
 import parquet.column.ParquetProperties.WriterVersion;
 import parquet.hadoop.CodecFactory.BytesCompressor;
 import parquet.hadoop.api.WriteSupport;
 import parquet.schema.MessageType;
-
 import static parquet.Preconditions.checkNotNull;
 
 /**
@@ -70,7 +71,7 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
       WriterVersion writerVersion) {
     internalWriter = new InternalParquetRecordWriter<T>(w, writeSupport, schema,
         extraMetaData, blockSize, pageSize, compressor, dictionaryPageSize, enableDictionary,
-        validating, writerVersion);
+        validating, writerVersion, new ParquetProperties(dictionaryPageSize, writerVersion, enableDictionary));
   }
 
   /**
@@ -99,7 +100,7 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
       MemoryManager memoryManager) {
     internalWriter = new InternalParquetRecordWriter<T>(w, writeSupport, schema,
         extraMetaData, blockSize, pageSize, compressor, dictionaryPageSize, enableDictionary,
-        validating, writerVersion);
+        validating, writerVersion, new ParquetProperties(dictionaryPageSize, writerVersion, enableDictionary));
     this.memoryManager = checkNotNull(memoryManager, "memoryManager");
     memoryManager.addWriter(internalWriter, blockSize);
   }

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetWriter.java
@@ -26,9 +26,11 @@ import org.apache.hadoop.fs.Path;
 
 import parquet.column.ParquetProperties;
 import parquet.column.ParquetProperties.WriterVersion;
+import parquet.hadoop.api.ReadSupport;
 import parquet.hadoop.api.WriteSupport;
 import parquet.hadoop.metadata.CompressionCodecName;
 import parquet.schema.MessageType;
+import static parquet.Preconditions.checkNotNull;
 
 /**
  * Write records to a Parquet file.
@@ -37,6 +39,7 @@ public class ParquetWriter<T> implements Closeable {
 
   public static final int DEFAULT_BLOCK_SIZE = 128 * 1024 * 1024;
   public static final int DEFAULT_PAGE_SIZE = 1 * 1024 * 1024;
+  public static final int DEFAULT_DICTIONARY_PAGE_SIZE = 1 * 1024 * 1024;
   public static final CompressionCodecName DEFAULT_COMPRESSION_CODEC_NAME =
       CompressionCodecName.UNCOMPRESSED;
   public static final boolean DEFAULT_IS_DICTIONARY_ENABLED = true;
@@ -57,7 +60,9 @@ public class ParquetWriter<T> implements Closeable {
    * @param pageSize the page size threshold
    * @throws IOException
    * @see #ParquetWriter(Path, WriteSupport, CompressionCodecName, int, int, boolean, boolean)
+   * @deprecated use {@link #builder(WriteSupport<T>, Path)}
    */
+  @Deprecated
   public ParquetWriter(Path file, WriteSupport<T> writeSupport, CompressionCodecName compressionCodecName, int blockSize, int pageSize) throws IOException {
     this(file, writeSupport, compressionCodecName, blockSize, pageSize,
         DEFAULT_IS_DICTIONARY_ENABLED, DEFAULT_IS_VALIDATING_ENABLED);
@@ -75,7 +80,9 @@ public class ParquetWriter<T> implements Closeable {
    * @param validating to turn on validation using the schema
    * @throws IOException
    * @see #ParquetWriter(Path, WriteSupport, CompressionCodecName, int, int, int, boolean, boolean)
+   * @deprecated use {@link #builder(WriteSupport<T>, Path)}
    */
+  @Deprecated
   public ParquetWriter(
       Path file,
       WriteSupport<T> writeSupport,
@@ -100,7 +107,9 @@ public class ParquetWriter<T> implements Closeable {
    * @param validating to turn on validation using the schema
    * @throws IOException
    * @see #ParquetWriter(Path, WriteSupport, CompressionCodecName, int, int, int, boolean, boolean, WriterVersion)
+   * @deprecated use {@link #builder(WriteSupport<T>, Path)}
    */
+  @Deprecated
   public ParquetWriter(
       Path file,
       WriteSupport<T> writeSupport,
@@ -132,7 +141,9 @@ public class ParquetWriter<T> implements Closeable {
    * @param writerVersion version of parquetWriter from {@link ParquetProperties.WriterVersion}
    * @throws IOException
    * @see #ParquetWriter(Path, WriteSupport, CompressionCodecName, int, int, int, boolean, boolean, WriterVersion, Configuration)
+   * @deprecated use {@link #builder(WriteSupport<T>, Path)}
    */
+  @Deprecated
   public ParquetWriter(
       Path file,
       WriteSupport<T> writeSupport,
@@ -160,7 +171,9 @@ public class ParquetWriter<T> implements Closeable {
    * @param writerVersion version of parquetWriter from {@link ParquetProperties.WriterVersion}
    * @param conf Hadoop configuration to use while accessing the filesystem
    * @throws IOException
+   * @deprecated use {@link #builder(WriteSupport<T>, Path)}
    */
+  @Deprecated
   public ParquetWriter(
       Path file,
       WriteSupport<T> writeSupport,
@@ -191,7 +204,10 @@ public class ParquetWriter<T> implements Closeable {
    * @param writerVersion version of parquetWriter from {@link ParquetProperties.WriterVersion}
    * @param conf Hadoop configuration to use while accessing the filesystem
    * @throws IOException
+   * @deprecated use {@link #builder(WriteSupport<T>, Path)}
    */
+  @Deprecated
+  // FIXME: make this constructor protected upon removing the deprecated stuff
   public ParquetWriter(
       Path file,
       ParquetFileWriter.Mode mode,
@@ -213,7 +229,7 @@ public class ParquetWriter<T> implements Closeable {
     fileWriter.start();
 
     CodecFactory codecFactory = new CodecFactory(conf);
-    CodecFactory.BytesCompressor compressor =	codecFactory.getCompressor(compressionCodecName, 0);
+    CodecFactory.BytesCompressor compressor = codecFactory.getCompressor(compressionCodecName, 0);
     this.writer = new InternalParquetRecordWriter<T>(
         fileWriter,
         writeSupport,
@@ -235,11 +251,14 @@ public class ParquetWriter<T> implements Closeable {
    * @param file the file to create
    * @param writeSupport the implementation to write a record to a RecordConsumer
    * @throws IOException
+   * @deprecated use {@link #builder(WriteSupport<T>, Path)}
    */
+  @Deprecated
   public ParquetWriter(Path file, WriteSupport<T> writeSupport) throws IOException {
     this(file, writeSupport, DEFAULT_COMPRESSION_CODEC_NAME, DEFAULT_BLOCK_SIZE, DEFAULT_PAGE_SIZE);
   }
 
+  @Deprecated
   public ParquetWriter(Path file, Configuration conf, WriteSupport<T> writeSupport) throws IOException {
     this(file,
         writeSupport,
@@ -251,6 +270,134 @@ public class ParquetWriter<T> implements Closeable {
         DEFAULT_IS_VALIDATING_ENABLED,
         DEFAULT_WRITER_VERSION,
         conf);
+  }
+  
+  /**
+   * Builder for the ParquetWriter class
+   * It is meant to be inherited by the builders of ParquetWriter's subclasses
+   */
+  protected static class Builder<T> {
+    // Maybe it will be wiser to make these private
+    // and provide access to the subclasses through getters.
+    protected Path file;
+    protected ParquetFileWriter.Mode mode;
+    protected WriteSupport<T> writeSupport;
+    protected CompressionCodecName compressionCodecName;
+    protected int blockSize;
+    protected int pageSize;
+    protected int dictionaryPageSize;
+    protected boolean enableDictionary;
+    protected boolean enableValidation;
+    protected WriterVersion writerVersion;
+    protected Configuration conf;
+
+    /**
+     * @param writeSupport the implementation to write a record to a RecordConsumer
+     * @param file the file to create
+     */
+    public Builder(WriteSupport<T> writeSupport, Path file) {
+      writeSupport = checkNotNull(writeSupport, "writeSupport");
+      file = checkNotNull(file, "file");
+      mode = ParquetFileWriter.Mode.CREATE;
+      compressionCodecName = DEFAULT_COMPRESSION_CODEC_NAME;
+      blockSize = DEFAULT_BLOCK_SIZE;
+      pageSize = DEFAULT_PAGE_SIZE;
+      dictionaryPageSize = DEFAULT_DICTIONARY_PAGE_SIZE;
+      enableDictionary = DEFAULT_IS_DICTIONARY_ENABLED;
+      enableValidation = DEFAULT_IS_VALIDATING_ENABLED;
+      writerVersion = DEFAULT_WRITER_VERSION;
+      conf = new Configuration();
+    }
+
+    /**
+     * @param mode file creation mode
+     */
+    public Builder<T> setFileWriteMode(ParquetFileWriter.Mode mode) {
+      this.mode = checkNotNull(mode, "mode");
+      return this;
+    }
+
+    /**
+     * @param compressionCodecName the compression codec to use
+     */
+    public Builder<T> setCompressionCodec(CompressionCodecName compressionCodecName) {
+      this.compressionCodecName = checkNotNull(compressionCodecName, "compressionCodecName");
+      return this;
+    }
+
+    /**
+     * @param blockSize the block size threshold
+     */
+    public Builder<T> setBlockSize(int blockSize) {
+      this.blockSize = blockSize;
+      return this;
+    }
+
+    /**
+     * @param pageSize the page size threshold
+     * @return
+     */
+    public Builder<T> setPageSize(int pageSize) {
+      this.pageSize = pageSize;
+      return this;
+    }
+
+    /**
+     * @param dictionaryPageSize the page size threshold for the dictionary pages
+     */
+    public Builder<T> setDictionaryPageSize(int dictionaryPageSize) {
+      this.dictionaryPageSize = dictionaryPageSize;
+      this.enableDictionary = true;
+      return this;
+    }
+
+    /**
+     * @param enableDictionary to turn dictionary encoding on
+     */
+    public Builder<T> enableDictionary(boolean enableDictionary) {
+      this.enableDictionary = enableDictionary;
+      return this;
+    }
+
+    /**
+     * @param enableValidation to turn on validation using the schema
+     */
+    public Builder<T> enableValidation(boolean enableValidation) {
+      this.enableValidation = enableValidation;
+      return this;
+    }
+
+    /**
+     * @param writerVersion version of parquetWriter from {@link ParquetProperties.WriterVersion}
+     */
+    public Builder<T> setWriterVersion(WriterVersion writerVersion) {
+      this.writerVersion = checkNotNull(writerVersion, "writerVersion");
+      return this;
+    }
+
+    /**
+     * @param conf Hadoop configuration to use while accessing the filesystem
+     */
+    public Builder<T> setConfiguration(Configuration conf) {
+      this.conf = checkNotNull(conf, "conf");
+      return this;
+    }
+    
+    /**
+     * @return a new instance of {@link ParquetWriter<T>}
+     * @throws IOException
+     */
+    public ParquetWriter<T> build() throws IOException {
+      return new ParquetWriter<T>(file, mode, writeSupport, compressionCodecName, blockSize,
+          pageSize, dictionaryPageSize, enableDictionary, enableValidation, writerVersion, conf);
+    }
+  }
+  
+  /**
+   * Convenience method for getting a new builder
+   */
+  public static <T> Builder<T> builder(WriteSupport<T> writeSupport, Path file) {
+    return new Builder<T>(writeSupport, file);
   }
 
   public void write(T object) throws IOException {

--- a/parquet-pig/src/test/java/parquet/pig/TupleConsumerPerfTest.java
+++ b/parquet-pig/src/test/java/parquet/pig/TupleConsumerPerfTest.java
@@ -31,6 +31,7 @@ import org.apache.pig.impl.util.Utils;
 import org.apache.pig.parser.ParserException;
 
 import parquet.Log;
+import parquet.column.ParquetProperties;
 import parquet.column.ParquetProperties.WriterVersion;
 import parquet.column.impl.ColumnWriteStoreV1;
 import parquet.column.page.PageReadStore;
@@ -59,7 +60,8 @@ public class TupleConsumerPerfTest {
     MessageType schema = new PigSchemaConverter().convert(Utils.getSchemaFromString(pigSchema));
 
     MemPageStore memPageStore = new MemPageStore(0);
-    ColumnWriteStoreV1 columns = new ColumnWriteStoreV1(memPageStore, 50*1024*1024, 50*1024*1024, false, WriterVersion.PARQUET_1_0);
+    ColumnWriteStoreV1 columns = new ColumnWriteStoreV1(memPageStore, 50*1024*1024, 50*1024*1024, false, WriterVersion.PARQUET_1_0,
+        new ParquetProperties(50*1024*1024, WriterVersion.PARQUET_1_0, false));
     write(memPageStore, columns, schema, pigSchema);
     columns.flush();
     read(memPageStore, pigSchema, pigSchemaProjected, pigSchemaNoString);

--- a/parquet-protobuf/src/main/java/parquet/proto/ProtoParquetWriter.java
+++ b/parquet-protobuf/src/main/java/parquet/proto/ProtoParquetWriter.java
@@ -18,14 +18,15 @@
  */
 package parquet.proto;
 
-import com.google.protobuf.Message;
-import com.google.protobuf.MessageOrBuilder;
+import java.io.IOException;
+
 import org.apache.hadoop.fs.Path;
+
 import parquet.hadoop.ParquetWriter;
-import parquet.hadoop.api.WriteSupport;
 import parquet.hadoop.metadata.CompressionCodecName;
 
-import java.io.IOException;
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
 
 /**
  * Write Protobuf records to a Parquet file.
@@ -40,7 +41,9 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
    * @param blockSize
    * @param pageSize
    * @throws IOException
+   * @deprecated use {@link #builder(Class<? extends Message>, Path)}
    */
+  @Deprecated
   public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage,
                             CompressionCodecName compressionCodecName, int blockSize,
                             int pageSize) throws IOException {
@@ -58,7 +61,9 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
    * @param enableDictionary     Whether to use a dictionary to compress columns.
    * @param validating           to turn on validation using the schema
    * @throws IOException
+   * @deprecated use {@link #builder(Class<? extends Message>, Path)}
    */
+  @Deprecated
   public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage,
                             CompressionCodecName compressionCodecName, int blockSize,
                             int pageSize, boolean enableDictionary, boolean validating) throws IOException {
@@ -72,10 +77,20 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
    *
    * @param file The file name to write to.
    * @throws IOException
+   * @deprecated use {@link #builder(Class<? extends Message>, Path)}
    */
+  @Deprecated
   public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage) throws IOException {
     this(file, protoMessage, CompressionCodecName.UNCOMPRESSED,
             DEFAULT_BLOCK_SIZE, DEFAULT_PAGE_SIZE);
+  }
+  
+  /**
+   * Convenience method for getting a new builder for {@link ProtoParquetWriter}
+   */
+  public static <T extends MessageOrBuilder> Builder<T> builder(
+      Class<? extends Message> protoMessage, Path file) {
+    return new Builder<T>(new ProtoWriteSupport<T>(protoMessage), file);
   }
 
 }

--- a/parquet-thrift/src/main/java/parquet/thrift/ThriftParquetWriter.java
+++ b/parquet-thrift/src/main/java/parquet/thrift/ThriftParquetWriter.java
@@ -37,18 +37,37 @@ import parquet.hadoop.thrift.TBaseWriteSupport;
  */
 public class ThriftParquetWriter<T extends TBase<?,?>> extends ParquetWriter<T> {
 
+  /**
+   * @deprecated use {@link #builder(Class<T>, Path)}
+   */
+  @Deprecated
   public ThriftParquetWriter(Path file, Class<T> thriftClass, CompressionCodecName compressionCodecName) throws IOException {
     super(file, new TBaseWriteSupport<T>(thriftClass), compressionCodecName, ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.DEFAULT_PAGE_SIZE);
   }
 
+  /**
+   * @deprecated use {@link #builder(Class<T>, Path)}
+   */
+  @Deprecated
   public ThriftParquetWriter(Path file, Class<T> thriftClass, CompressionCodecName compressionCodecName, int blockSize, int pageSize, boolean enableDictionary, boolean validating) throws IOException {
     super(file, new TBaseWriteSupport<T>(thriftClass), compressionCodecName, blockSize, pageSize, enableDictionary, validating);
   }
 
+  /**
+   * @deprecated use {@link #builder(Class<T>, Path)}
+   */
+  @Deprecated
   public ThriftParquetWriter(Path file, Class<T> thriftClass, CompressionCodecName compressionCodecName, int blockSize, int pageSize, boolean enableDictionary, boolean validating, Configuration conf) throws IOException {
     super(file, new TBaseWriteSupport<T>(thriftClass), compressionCodecName,
         blockSize, pageSize, pageSize, enableDictionary, validating,
         DEFAULT_WRITER_VERSION, conf);
+  }
+  
+  /**
+   * Convenience method for getting a new builder for {@link ProtoParquetWriter}
+   */
+  public static <T extends TBase<?,?>> Builder<T> builder(Class<T> thriftClass, Path file) {
+    return new Builder<T>(new TBaseWriteSupport<T>(thriftClass), file);
   }
 
 }

--- a/parquet-thrift/src/test/java/parquet/thrift/TestParquetReadProtocol.java
+++ b/parquet-thrift/src/test/java/parquet/thrift/TestParquetReadProtocol.java
@@ -38,6 +38,7 @@ import org.apache.thrift.TException;
 import org.junit.Test;
 
 import parquet.Log;
+import parquet.column.ParquetProperties;
 import parquet.column.ParquetProperties.WriterVersion;
 import parquet.column.impl.ColumnWriteStoreV1;
 import parquet.column.page.mem.MemPageStore;
@@ -148,7 +149,8 @@ public class TestParquetReadProtocol {
     final MessageType schema = schemaConverter.convert(thriftClass);
     LOG.info(schema);
     final MessageColumnIO columnIO = new ColumnIOFactory(true).getColumnIO(schema);
-    final ColumnWriteStoreV1 columns = new ColumnWriteStoreV1(memPageStore, 10000, 10000, false, WriterVersion.PARQUET_1_0);
+    final ColumnWriteStoreV1 columns = new ColumnWriteStoreV1(memPageStore, 10000, 10000, false, WriterVersion.PARQUET_1_0, 
+        new ParquetProperties(10000, WriterVersion.PARQUET_1_0, false));
     final RecordConsumer recordWriter = columnIO.getRecordWriter(columns);
     final StructType thriftType = schemaConverter.toStructType(thriftClass);
     ParquetWriteProtocol parquetWriteProtocol = new ParquetWriteProtocol(recordWriter, columnIO, thriftType);


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/PARQUET-226

There are use-cases in which it is advantageous to have control over the type of encoding used for a given column. To achieve this, the ParquetProperties class must be refactored to facilitate its subclassing. The constructors of ParquetWriter and (probably) InternalParquetRecordWriter have to be modified as well. All the internal parquet classes have to refrain from directly instantiating ParquetProperties and should accept the instance from outside.
Currently me and my team are using a good amount of reflection and unenforceable assumptions in order to gain control of this behavior. I'd like to implement the interface change. Are you interested in this feature?