### PR TITLE
PARQUET-239: Make AvroParquetReader#builder static.

### DIFF
--- a/parquet-avro/src/main/java/parquet/avro/AvroParquetReader.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroParquetReader.java
@@ -32,7 +32,7 @@ import parquet.hadoop.ParquetReader;
  */
 public class AvroParquetReader<T extends IndexedRecord> extends ParquetReader<T> {
 
-  public Builder<T> builder(Path file) {
+  public static <T extends IndexedRecord> Builder<T> builder(Path file) {
     return ParquetReader.builder(new AvroReadSupport<T>(), file);
   }
 


### PR DESCRIPTION
Fixes new API method added since 1.5.0.