### PR TITLE
PARQUET-242: Fix AvroReadSupport.setAvroDataSupplier.

### DIFF
--- a/parquet-avro/src/main/java/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroReadSupport.java
@@ -61,7 +61,7 @@ public class AvroReadSupport<T extends IndexedRecord> extends ReadSupport<T> {
 
   public static void setAvroDataSupplier(Configuration configuration,
       Class<? extends AvroDataSupplier> clazz) {
-    configuration.set(AVRO_DATA_SUPPLIER, clazz.toString());
+    configuration.set(AVRO_DATA_SUPPLIER, clazz.getName());
   }
 
   @Override

--- a/parquet-avro/src/test/java/parquet/avro/TestAvroDataSupplier.java
+++ b/parquet-avro/src/test/java/parquet/avro/TestAvroDataSupplier.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package parquet.avro;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestAvroDataSupplier {
+
+  public static class GenericDataSupplier implements AvroDataSupplier {
+    @Override
+    public GenericData get() {
+      return GenericData.get();
+    }
+  }
+
+  @Test
+  public void testSetSupplierMethod() {
+    Configuration conf = new Configuration(false);
+    AvroReadSupport.setAvroDataSupplier(conf, GenericDataSupplier.class);
+    Assert.assertEquals("Should contain the class name",
+        "parquet.avro.TestAvroDataSupplier$GenericDataSupplier",
+        conf.get(AvroReadSupport.AVRO_DATA_SUPPLIER));
+  }
+}


### PR DESCRIPTION
This should use the supplier class's name, rather than its toString
representation or else loading the class doesn't work.