### PR TITLE
PARQUET-235: Fix parquet.metadata compatibility.

### DIFF
--- a/parquet-column/src/main/java/parquet/filter2/predicate/FilterApi.java
+++ b/parquet-column/src/main/java/parquet/filter2/predicate/FilterApi.java
@@ -20,7 +20,7 @@ package parquet.filter2.predicate;
 
 import java.io.Serializable;
 
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.filter2.predicate.Operators.And;
 import parquet.filter2.predicate.Operators.BinaryColumn;
 import parquet.filter2.predicate.Operators.BooleanColumn;

--- a/parquet-column/src/main/java/parquet/filter2/predicate/Operators.java
+++ b/parquet-column/src/main/java/parquet/filter2/predicate/Operators.java
@@ -20,7 +20,7 @@ package parquet.filter2.predicate;
 
 import java.io.Serializable;
 
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.io.api.Binary;
 
 import static parquet.Preconditions.checkNotNull;

--- a/parquet-column/src/main/java/parquet/filter2/predicate/SchemaCompatibilityValidator.java
+++ b/parquet-column/src/main/java/parquet/filter2/predicate/SchemaCompatibilityValidator.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import parquet.column.ColumnDescriptor;
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.filter2.predicate.Operators.And;
 import parquet.filter2.predicate.Operators.Column;
 import parquet.filter2.predicate.Operators.ColumnFilterPredicate;

--- a/parquet-column/src/main/java/parquet/filter2/predicate/ValidTypeMap.java
+++ b/parquet-column/src/main/java/parquet/filter2/predicate/ValidTypeMap.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.filter2.predicate.Operators.Column;
 import parquet.io.api.Binary;
 import parquet.schema.OriginalType;

--- a/parquet-column/src/main/java/parquet/filter2/recordlevel/FilteringGroupConverter.java
+++ b/parquet-column/src/main/java/parquet/filter2/recordlevel/FilteringGroupConverter.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.filter2.recordlevel.IncrementallyUpdatedFilterPredicate.ValueInspector;
 import parquet.io.PrimitiveColumnIO;
 import parquet.io.api.Converter;

--- a/parquet-column/src/main/java/parquet/filter2/recordlevel/FilteringRecordMaterializer.java
+++ b/parquet-column/src/main/java/parquet/filter2/recordlevel/FilteringRecordMaterializer.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.filter2.recordlevel.IncrementallyUpdatedFilterPredicate.ValueInspector;
 import parquet.io.PrimitiveColumnIO;
 import parquet.io.api.GroupConverter;

--- a/parquet-column/src/main/java/parquet/filter2/recordlevel/IncrementallyUpdatedFilterPredicateBuilderBase.java
+++ b/parquet-column/src/main/java/parquet/filter2/recordlevel/IncrementallyUpdatedFilterPredicateBuilderBase.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.filter2.predicate.FilterPredicate;
 import parquet.filter2.predicate.FilterPredicate.Visitor;
 import parquet.filter2.predicate.Operators.And;

--- a/parquet-column/src/test/java/parquet/filter2/predicate/TestFilterApiMethods.java
+++ b/parquet-column/src/test/java/parquet/filter2/predicate/TestFilterApiMethods.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
 
 import org.junit.Test;
 
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.filter2.predicate.Operators.And;
 import parquet.filter2.predicate.Operators.BinaryColumn;
 import parquet.filter2.predicate.Operators.DoubleColumn;

--- a/parquet-column/src/test/java/parquet/filter2/predicate/TestValidTypeMap.java
+++ b/parquet-column/src/test/java/parquet/filter2/predicate/TestValidTypeMap.java
@@ -20,7 +20,7 @@ package parquet.filter2.predicate;
 
 import org.junit.Test;
 
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.filter2.predicate.Operators.BinaryColumn;
 import parquet.filter2.predicate.Operators.BooleanColumn;
 import parquet.filter2.predicate.Operators.Column;

--- a/parquet-common/src/main/java/parquet/hadoop/metadata/Canonicalizer.java
+++ b/parquet-common/src/main/java/parquet/hadoop/metadata/Canonicalizer.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package parquet.common.internal;
+package parquet.hadoop.metadata;
 
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/parquet-common/src/main/java/parquet/hadoop/metadata/ColumnPath.java
+++ b/parquet-common/src/main/java/parquet/hadoop/metadata/ColumnPath.java
@@ -16,13 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package parquet.common.schema;
+package parquet.hadoop.metadata;
 
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
-
-import parquet.common.internal.Canonicalizer;
 
 import static parquet.Preconditions.checkNotNull;
 

--- a/parquet-generator/src/main/java/parquet/filter2/IncrementallyUpdatedFilterPredicateGenerator.java
+++ b/parquet-generator/src/main/java/parquet/filter2/IncrementallyUpdatedFilterPredicateGenerator.java
@@ -68,7 +68,7 @@ public class IncrementallyUpdatedFilterPredicateGenerator {
   public void run() throws IOException {
     add("package parquet.filter2.recordlevel;\n" +
         "\n" +
-        "import parquet.common.schema.ColumnPath;\n" +
+        "import parquet.hadoop.metadata.ColumnPath;\n" +
         "import parquet.filter2.predicate.Operators.Eq;\n" +
         "import parquet.filter2.predicate.Operators.Gt;\n" +
         "import parquet.filter2.predicate.Operators.GtEq;\n" +

--- a/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
+++ b/parquet-hadoop/src/main/java/parquet/filter2/statisticslevel/StatisticsFilter.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import parquet.column.statistics.Statistics;
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.filter2.predicate.FilterPredicate;
 import parquet.filter2.predicate.Operators.And;
 import parquet.filter2.predicate.Operators.Column;

--- a/parquet-hadoop/src/main/java/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/parquet/format/converter/ParquetMetadataConverter.java
@@ -36,7 +36,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import parquet.Log;
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.format.ColumnChunk;
 import parquet.format.ColumnMetaData;
 import parquet.format.ConvertedType;

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetFileReader.java
@@ -61,7 +61,7 @@ import parquet.column.page.DataPageV1;
 import parquet.column.page.DataPageV2;
 import parquet.column.page.DictionaryPage;
 import parquet.column.page.PageReadStore;
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.format.DataPageHeader;
 import parquet.format.DataPageHeaderV2;
 import parquet.format.DictionaryPageHeader;

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetFileWriter.java
@@ -43,7 +43,7 @@ import parquet.bytes.BytesUtils;
 import parquet.column.ColumnDescriptor;
 import parquet.column.page.DictionaryPage;
 import parquet.column.statistics.Statistics;
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.format.converter.ParquetMetadataConverter;
 import parquet.hadoop.metadata.BlockMetaData;
 import parquet.hadoop.metadata.ColumnChunkMetaData;

--- a/parquet-hadoop/src/main/java/parquet/hadoop/metadata/ColumnChunkMetaData.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/metadata/ColumnChunkMetaData.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import parquet.column.Encoding;
 import parquet.column.statistics.BooleanStatistics;
 import parquet.column.statistics.Statistics;
-import parquet.common.schema.ColumnPath;
 import parquet.schema.PrimitiveType.PrimitiveTypeName;
 
 /**

--- a/parquet-hadoop/src/main/java/parquet/hadoop/metadata/ColumnChunkProperties.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/metadata/ColumnChunkProperties.java
@@ -22,8 +22,6 @@ import java.util.Arrays;
 import java.util.Set;
 
 import parquet.column.Encoding;
-import parquet.common.internal.Canonicalizer;
-import parquet.common.schema.ColumnPath;
 import parquet.schema.PrimitiveType.PrimitiveTypeName;
 
 public class ColumnChunkProperties {

--- a/parquet-hadoop/src/main/java/parquet/hadoop/metadata/EncodingList.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/metadata/EncodingList.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import parquet.column.Encoding;
-import parquet.common.internal.Canonicalizer;
 
 public class EncodingList implements Iterable<Encoding> {
 

--- a/parquet-hadoop/src/test/java/parquet/filter2/statisticslevel/TestStatisticsFilter.java
+++ b/parquet-hadoop/src/test/java/parquet/filter2/statisticslevel/TestStatisticsFilter.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import parquet.column.Encoding;
 import parquet.column.statistics.DoubleStatistics;
 import parquet.column.statistics.IntStatistics;
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.filter2.predicate.FilterPredicate;
 import parquet.filter2.predicate.LogicalInverseRewriter;
 import parquet.filter2.predicate.Operators.DoubleColumn;

--- a/parquet-hadoop/src/test/java/parquet/hadoop/TestInputFormat.java
+++ b/parquet-hadoop/src/test/java/parquet/hadoop/TestInputFormat.java
@@ -53,7 +53,7 @@ import parquet.column.ColumnReader;
 import parquet.column.Encoding;
 import parquet.column.statistics.BinaryStatistics;
 import parquet.column.statistics.IntStatistics;
-import parquet.common.schema.ColumnPath;
+import parquet.hadoop.metadata.ColumnPath;
 import parquet.filter.RecordFilter;
 import parquet.filter.UnboundRecordFilter;
 import parquet.filter2.compat.FilterCompat;

--- a/parquet-hadoop/src/test/java/parquet/hadoop/metadata/TestColumnChunkMetaData.java
+++ b/parquet-hadoop/src/test/java/parquet/hadoop/metadata/TestColumnChunkMetaData.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 
 import parquet.column.Encoding;
 import parquet.column.statistics.BinaryStatistics;
-import parquet.common.schema.ColumnPath;
 import parquet.schema.PrimitiveType.PrimitiveTypeName;
 
 import static org.junit.Assert.assertEquals;

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <cascading.version>2.5.3</cascading.version>
     <parquet.format.version>2.2.0-rc1</parquet.format.version>
     <log4j.version>1.2.17</log4j.version>
-    <previous.version>1.6.0rc1</previous.version>
+    <previous.version>1.5.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <scala.version>2.10.4</scala.version>
     <!-- scala.binary.version is used for projects that fetch dependencies that are in scala -->
@@ -237,6 +237,10 @@
                      <exclude>parquet/org/**</exclude>
                      <exclude>parquet/column/**</exclude>
                      <exclude>parquet/hadoop/ParquetInputSplit</exclude>
+                     <!-- temporary rules -->
+                     <exclude>parquet/io/api/Binary</exclude> <!-- false positive, added interfaces -->
+                     <exclude>parquet/hadoop/metadata/Canonicalizer</exclude> <!-- moved to different module -->
+                     <exclude>parquet/hadoop/metadata/ColumnPath</exclude> <!-- moved to different module, added methods -->
                    </excludes>
                  </requireBackwardCompatibility>
                </rules>


### PR DESCRIPTION
ColumnPath and Canonicalizer were moved from parquet-hadoop to
parquet-common in parquet.common.{internal,schema}, which broke
compatibility and would require bumping the major version. This moves
the classes back into parquet.hadoop.metadata and adds temporary
exclusions for the move between modules. There are no breaking changes
to the classes themselves, verified by copying them into parquet-hadoop
and building.

This also changes the previous version back to 1.5.0 rather than an RC
(which carries no compatibility guarantees, though this is compatible
with both version). It also adds an exclusions for a false positive in
Binary.