### PR TITLE
PARQUET-213: Logs discarded and projected fields after projection pushdown.

### DIFF
--- a/parquet-thrift/src/main/java/parquet/thrift/ThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/main/java/parquet/thrift/ThriftSchemaConvertVisitor.java
@@ -35,6 +35,7 @@ import static parquet.schema.Types.primitive;
 import java.util.ArrayList;
 import java.util.List;
 
+import parquet.Log;
 import parquet.schema.GroupType;
 import parquet.schema.MessageType;
 import parquet.schema.OriginalType;
@@ -44,6 +45,7 @@ import parquet.schema.Type;
 import parquet.schema.Types.PrimitiveBuilder;
 import parquet.thrift.projection.FieldProjectionFilter;
 import parquet.thrift.projection.FieldsPath;
+import parquet.thrift.projection.ProjectionFilter;
 import parquet.thrift.projection.ThriftProjectionException;
 import parquet.thrift.struct.ThriftField;
 import parquet.thrift.struct.ThriftType;
@@ -56,17 +58,19 @@ import parquet.thrift.struct.ThriftType;
  */
 public class ThriftSchemaConvertVisitor implements ThriftType.TypeVisitor {
 
-  public FieldProjectionFilter getFieldProjectionFilter() {
-    return fieldProjectionFilter;
-  }
+    private static final Log logger = Log.getLog(ThriftSchemaConvertVisitor.class);
 
-  FieldProjectionFilter fieldProjectionFilter;
+    public ProjectionFilter getFieldProjectionFilter() {
+        return fieldProjectionFilter;
+    }
+
+  ProjectionFilter fieldProjectionFilter;
   Type currentType;
   FieldsPath currentFieldPath = new FieldsPath();
   Type.Repetition currentRepetition = Type.Repetition.REPEATED;//MessageType is repeated GroupType
   String currentName = "ParquetSchema";
 
-  public ThriftSchemaConvertVisitor(FieldProjectionFilter fieldProjectionFilter) {
+  public ThriftSchemaConvertVisitor(ProjectionFilter fieldProjectionFilter) {
     this.fieldProjectionFilter = fieldProjectionFilter;
   }
 
@@ -145,6 +149,15 @@ public class ThriftSchemaConvertVisitor implements ThriftType.TypeVisitor {
   }
 
   public MessageType getConvertedMessageType() {
+    logger.info("project fields");
+    for (String path : fieldProjectionFilter.getMatchedPaths()) {
+      logger.info(path);
+    }
+
+    logger.info("\n\ndiscarded fields");
+    for (String path : fieldProjectionFilter.getUnmatchedPaths()) {
+      logger.info(path);
+    }
     // the root should be a GroupType
     if (currentType == null)
       return new MessageType(currentName, new ArrayList<Type>());

--- a/parquet-thrift/src/main/java/parquet/thrift/ThriftSchemaConverter.java
+++ b/parquet-thrift/src/main/java/parquet/thrift/ThriftSchemaConverter.java
@@ -27,6 +27,7 @@ import org.apache.thrift.TUnion;
 import parquet.schema.MessageType;
 import parquet.thrift.projection.FieldProjectionFilter;
 import parquet.thrift.projection.PathGlobPattern;
+import parquet.thrift.projection.ProjectionFilter;
 import parquet.thrift.projection.ThriftProjectionException;
 import parquet.thrift.struct.ThriftField;
 import parquet.thrift.struct.ThriftField.Requirement;
@@ -71,7 +72,7 @@ public class ThriftSchemaConverter {
     return convertedMessageType;
   }
 
-  private void checkUnmatchedProjectionFilter(FieldProjectionFilter filter) {
+  private void checkUnmatchedProjectionFilter(ProjectionFilter filter) {
     List<PathGlobPattern> unmatched = filter.getUnMatchedPatterns();
     if (unmatched.size() != 0) {
       throw new ThriftProjectionException("unmatched projection filters: " + unmatched.toString());
@@ -82,7 +83,7 @@ public class ThriftSchemaConverter {
     return new ThriftStructConverter().toStructType(thriftClass);
   }
 
-  private static class ThriftStructConverter {
+  protected static class ThriftStructConverter {
 
     public ThriftType.StructType toStructType(Class<? extends TBase<?, ?>> thriftClass) {
       final TStructDescriptor struct = TStructDescriptor.getInstance(thriftClass);

--- a/parquet-thrift/src/main/java/parquet/thrift/projection/ProjectionFilter.java
+++ b/parquet-thrift/src/main/java/parquet/thrift/projection/ProjectionFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package parquet.thrift.projection;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Mansur Ashraf.
+ */
+public interface ProjectionFilter {
+  boolean isMatched(FieldsPath path);
+  List<PathGlobPattern> getUnMatchedPatterns();
+  public Set<String> getMatchedPaths();
+  public Set<String> getUnmatchedPaths();
+}


### PR DESCRIPTION
Reviving the old PR after clean up. I noticed that @isnotinvain has added new projection filter API so not sure if this change still applies